### PR TITLE
Support integration-tests manual-trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
       timeout-minutes: 30
 
   # Run integration-tests on devnet deployed by Godowoken-Kicker
-  devnet:
+  test-on-devnet:
     needs: prepare-image
     runs-on: ubuntu-latest
     if: ${{ true }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,20 +36,23 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # - name: Download ckb-indexer-data
-    #   run: |
-    #     docker run --rm \
-    #       -v /ckb-indexer-data:/ckb-indexer-data \
-    #       ghcr.io/flouse/testnet-polyjuice-api:latest bash -c \
-    #       "cp /godwoken-polyman/packages/runner/db/ckb-indexer-testnet/* /ckb-indexer-data/"
-    #     sudo chown -R `whoami` /ckb-indexer-data
+    - name: Download ckb-indexer-data
+      run: |
+        docker run --rm \
+          -v /ckb-indexer-data:/ckb-indexer-data \
+          ghcr.io/flouse/testnet-polyjuice-api:latest bash -c \
+          "cp /godwoken-polyman/packages/runner/db/ckb-indexer-testnet/* /ckb-indexer-data/"
+        sudo chown -R `whoami` /ckb-indexer-data
 
-    # - name: Start ckb-indexer
-    #   run: |
-    #     docker run -p 8116:8116 -i \
-    #       -v /ckb-indexer-data:/ckb-indexer-data \
-    #       ${{ env.GODWOKEN_PREBUILDS_IMAGE }} \
-    #       sh -c "RUST_LOG=info ckb-indexer -c http://3.235.223.161:18114 -s /ckb-indexer-data"
+    - name: Start ckb-indexer
+      run: |
+        docker create --name ckb-indexer-0.3 -p 8116:8116 \
+          -v /ckb-indexer-data:/ckb-indexer-data \
+          ${{ env.GODWOKEN_PREBUILDS_IMAGE }} \
+          sh -c "RUST_LOG=info ckb-indexer -c https://testnet.ckbapp.dev/rpc -s /ckb-indexer-data -l 0.0.0.0:8116"
+        docker start ckb-indexer-0.3
+        echo "sleep 1 minute..." && sleep 60
+        docker logs ckb-indexer-0.3 --tail 20
 
     # - name: Store Cache of Godwoken Testnet
     #   uses: actions/cache@v2
@@ -62,15 +65,20 @@ jobs:
     - name: readonly-testnet-node-sync-to-tip
       run: |
         cd configs
-        docker run -i -w /deploy --network host \
+        mv gw-testnet-config.toml gw-testnet-config.toml.bak
+        sed "s+indexer_url =.*+indexer_url = 'http://localhost:8116'+g" gw-testnet-config.toml.bak > gw-testnet-config.toml
+        docker run -w /deploy --network host \
+          --name readonly-testnet-node-sync-to-tip \
+          -d --restart unless-stopped	\
           -v `pwd`/gw-testnet-config.toml:/deploy/gw-testnet-config.toml \
           -v `pwd`/pk:/deploy/pk \
           -v `pwd`/store.db:/deploy/store.db \
-          ${{ env.GODWOKEN_PREBUILDS_IMAGE }} bash -c "RUST_LOG=gw=debug godwoken run -c gw-testnet-config.toml"
+          ${{ env.GODWOKEN_PREBUILDS_IMAGE }} bash -c "RUST_LOG=debug godwoken run -c gw-testnet-config.toml"
+        docker logs readonly-testnet-node-sync-to-tip -f
       timeout-minutes: 120
 
     - name: Setup tmate session for debugging if something failed
-      if: ${{ failure() }}
+      # if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 30
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,7 @@ jobs:
           sed \
             -e "s|MANUAL_BUILD_GODWOKEN=false|MANUAL_BUILD_GODWOKEN=true|g" \
             -e "s|GODWOKEN_GIT_CHECKOUT=.*|GODWOKEN_GIT_CHECKOUT=${{ github.event.inputs.godwoken }}|g" \
+            -e "s|BUILD_GODWOKEN_ON_LOCAL_OVER_DOCKER=false|BUILD_GODWOKEN_ON_LOCAL_OVER_DOCKER=true|g" \
             .build.mode.env.bak > .build.mode.env
         fi
         if [ -n "${{ github.event.inputs.godwoken-scripts }}" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,22 +3,34 @@ name: Integration Test
 on:
   workflow_dispatch:
     inputs:
-      prebuild-image:
-        description: 'https://github.com/nervosnetwork/godwoken-docker-prebuilds'
+      gw_prebuild_image_name:
+        description: 'The prebuild image name'
+        required: true
+        default: 'ghcr.io/flouse/godwoken-prebuilds'
+      gw_prebuild_image_tag:
+        description: 'The prebuild image tag'
+        required: true
+        default: 'latest'
+      godwoken:
+        description: 'Godwoken version'
         required: false
-        default: 'ghcr.io/flouse/godwoken-prebuilds:latest'
-      # godwoken:
-      #   description: 'godwoken version'
+        # default: 'The version in prebuild-image'
+      godwoken-scripts:
+        description: 'Godwoken-scripts version'
+        required: false
+        # default: 'The version in prebuild-image'
+      polyjuice:
+        description: 'Polyjuice version'
+        required: false
+        # default: 'The version in prebuild-image'
+      testnet-sync:
+        description: 'Whether to run a godwoken readonly node and sync to testnet tip'
+        required: false
+        default: 'false'
+      # logLevel:
+      #   description: 'Log level'   
       #   required: false
-      #   default: 'The version in prebuild-image'
-      # godwoken-scripts:
-      #   description: 'godwoken-scripts version'
-      #   required: false
-      #   default: 'The version in prebuild-image'
-      # polyjuice:
-      #   description: 'polyjuice version'
-      #   required: false
-      #   default: 'The version in prebuild-image'
+      #   default: 'INFO'
   push:
     branches:
     - CI
@@ -28,11 +40,46 @@ on:
     branches:
     - develop
 
+env:
+  GW_PREBUILDS_IMAGE_NAME: ghcr.io/flouse/godwoken-prebuilds
+  GW_PREBUILD_IMAGE_TAG: latest
+  GODWOKEN_GIT_URL: https://github.com/nervosnetwork/godwoken.git
+  GODWOKEN_REF: master
+  GW_SCRIPTS_GIT_URL: https://github.com/nervosnetwork/godwoken-scripts.git
+  GW_SCRIPTS_REF: master
+  POLYJUICE_GIT_URL: https://github.com/nervosnetwork/godwoken-polyjuice.git
+  POLYJUICE_REF: main
+
 jobs:
-  readonly-testnet-node-sync-to-tip:
-    env:
-      GODWOKEN_PREBUILDS_IMAGE: nervos/godwoken-prebuilds:v0.6.5-rc3
+  prepare-image:
     runs-on: ubuntu-latest
+    outputs: # Map a step output to a job output
+      GW_PREBUILDS_IMAGE_NAME: ${{ steps.env-switcher.outputs.GW_PREBUILDS_IMAGE_NAME }}
+      GW_PREBUILD_IMAGE_TAG: ${{ steps.env-switcher.outputs.GW_PREBUILD_IMAGE_TAG }}
+    steps:
+    - name: Setup envs
+      id: env-switcher
+      run: |
+        echo "inputs: ${{ toJSON(github.event.inputs) }}"
+        if [ -n "${{ github.event.inputs.gw_prebuild_image_name }}" ]; then 
+          echo "GW_PREBUILDS_IMAGE=${{ github.event.inputs.gw_prebuild_image_name }}:${{ github.event.inputs.gw_prebuild_image_tag }}" >> $GITHUB_ENV
+          echo "::set-output name=GW_PREBUILDS_IMAGE_NAME::${{ github.event.inputs.gw_prebuild_image_name }}"
+          echo "::set-output name=GW_PREBUILD_IMAGE_TAG::${{ github.event.inputs.gw_prebuild_image_tag }}"
+        else
+          echo "GW_PREBUILDS_IMAGE=${{ env.GW_PREBUILDS_IMAGE_NAME }}:${{ env.GW_PREBUILD_IMAGE_TAG }}" >> $GITHUB_ENV
+          echo "::set-output name=GW_PREBUILDS_IMAGE_NAME::${{ env.GW_PREBUILDS_IMAGE_NAME }}"
+          echo "::set-output name=GW_PREBUILD_IMAGE_TAG::${{ env.GW_PREBUILD_IMAGE_TAG }}"
+        fi
+    - run: |
+        echo "env.GW_PREBUILDS_IMAGE: ${{ env.GW_PREBUILDS_IMAGE }}"
+        echo "TODO: build image from https://github.com/Flouse/godwoken-docker-prebuilds"
+    
+    # TODO: build image if the tag is not exist
+
+  readonly-testnet-node-sync-to-tip:
+    needs: prepare-image
+    runs-on: ubuntu-latest
+    if: ${{ false }} # testnet-sync: false
     steps:
     - uses: actions/checkout@v2
 
@@ -48,7 +95,7 @@ jobs:
       run: |
         docker create --name ckb-indexer-0.3 -p 8116:8116 \
           -v /ckb-indexer-data:/ckb-indexer-data \
-          ${{ env.GODWOKEN_PREBUILDS_IMAGE }} \
+          ${{ env.GW_PREBUILDS_IMAGE_NAME }}:${{ env.GW_PREBUILD_IMAGE_TAG }} \
           sh -c "RUST_LOG=info ckb-indexer -c https://testnet.ckbapp.dev/rpc -s /ckb-indexer-data -l 0.0.0.0:8116"
         docker start ckb-indexer-0.3
         echo "sleep 1 minute..." && sleep 60
@@ -73,19 +120,21 @@ jobs:
           -v `pwd`/gw-testnet-config.toml:/deploy/gw-testnet-config.toml \
           -v `pwd`/pk:/deploy/pk \
           -v `pwd`/store.db:/deploy/store.db \
-          ${{ env.GODWOKEN_PREBUILDS_IMAGE }} bash -c "RUST_LOG=debug godwoken run -c gw-testnet-config.toml"
+          ${{ env.GW_PREBUILDS_IMAGE_NAME }}:${{ env.GW_PREBUILD_IMAGE_TAG }} \
+          bash -c "godwoken run -c gw-testnet-config.toml"
         docker logs readonly-testnet-node-sync-to-tip -f
       timeout-minutes: 120
 
     - name: Setup tmate session for debugging if something failed
-      # if: ${{ failure() }}
+      if: ${{ failure() }} # TODO: or cancelled() 
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 30
 
-  # Run integration-tests base on Godowoken-Kicker services
+  # Run integration-tests on devnet deployed by Godowoken-Kicker
   devnet:
+    needs: prepare-image
     runs-on: ubuntu-latest
-
+    if: ${{ true }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -95,11 +144,12 @@ jobs:
     # make the Docker cache exportable and thus properly cacheable
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    # In this step, this action saves a list of existing images,
-    # the cache is created without them in the post run.
-    # It also restores the cache if it exists.
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true # Ignore the failure of a step and avoid terminating the job.
+
+    # # In this step, this action saves a list of existing images,
+    # # the cache is created without them in the post run.
+    # # It also restores the cache if it exists.
+    # - uses: satackey/action-docker-layer-caching@v0.0.11
+    #   continue-on-error: true # Ignore the failure of a step and avoid terminating the job.
 
     # - name: Cache Docker layers
     #   uses: actions/cache@v2
@@ -118,19 +168,48 @@ jobs:
           ~/.cargo/git
           target
           kicker/cache/build
-        # kicker/packages/godwoken/target
-        # kicker/packages
         key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
     - name: Install moleculec
       run: |
-        test "$(moleculec --version)" = "Moleculec 0.6.1" \
-        || CARGO_TARGET_DIR=target/ cargo install moleculec --version 0.6.1
+        test "$(moleculec --version)" = "Moleculec 0.7.2" \
+        || CARGO_TARGET_DIR=target/ cargo install moleculec --version 0.7.2 --force
     - name: Install Capsule
       run: |
         test "$(capsule -V)" = "Capsule 0.4.6 36d59e0" \
         || CARGO_TARGET_DIR=target/ cargo install ckb-capsule \
         --git https://github.com/nervosnetwork/capsule.git \
         --tag v0.4.6
+
+    - name: Replace the envs in kicker/docker/.build.mode.env
+      working-directory: kicker/docker/
+      run: |
+        mv .build.mode.env .build.mode.env.bak
+        sed \
+          -e "s|DOCKER_PREBUILD_IMAGE_NAME=.*|DOCKER_PREBUILD_IMAGE_NAME=${{ needs.prepare-image.outputs.GW_PREBUILDS_IMAGE_NAME }}|g" \
+          -e "s|DOCKER_PREBUILD_IMAGE_TAG=.*|DOCKER_PREBUILD_IMAGE_TAG=${{ needs.prepare-image.outputs.GW_PREBUILD_IMAGE_TAG }}|g" \
+          .build.mode.env.bak > .build.mode.env
+        if [ -n "${{ github.event.inputs.godwoken }}" ]; then
+          mv .build.mode.env .build.mode.env.bak
+          sed \
+            -e "s|MANUAL_BUILD_GODWOKEN=false|MANUAL_BUILD_GODWOKEN=true|g" \
+            -e "s|GODWOKEN_GIT_CHECKOUT=.*|GODWOKEN_GIT_CHECKOUT=${{ github.event.inputs.godwoken }}|g" \
+            .build.mode.env.bak > .build.mode.env
+        fi
+        if [ -n "${{ github.event.inputs.godwoken-scripts }}" ]; then
+          mv .build.mode.env .build.mode.env.bak
+          sed \
+            -e "s|MANUAL_BUILD_SCRIPTS=false|MANUAL_BUILD_SCRIPTS=true|g" \
+            -e "s|SCRIPTS_GIT_CHECKOUT=.*|SCRIPTS_GIT_CHECKOUT=${{ github.event.inputs.godwoken-scripts }}|g" \
+            .build.mode.env.bak > .build.mode.env
+        fi
+        if [ -n "${{ github.event.inputs.polyjuice }}" ]; then
+          mv .build.mode.env .build.mode.env.bak
+          sed \
+            -e "s|MANUAL_BUILD_POLYJUICE=false|MANUAL_BUILD_POLYJUICE=true|g" \
+            -e "s|POLYJUICE_GIT_CHECKOUT=.*|POLYJUICE_GIT_CHECKOUT=${{ github.event.inputs.polyjuice }}|g" \
+            .build.mode.env.bak > .build.mode.env
+        fi
+        cat .build.mode.env
 
     - name: Start Godwoken-Kicker services
       working-directory: kicker
@@ -148,7 +227,6 @@ jobs:
         make start
         docker-compose --file docker/docker-compose.yml logs --tail 6
         sudo chown -R `whoami` cache/build
-      # sudo chown -R `whoami` packages/godwoken/target
       # TODO: check servics 
 
     - uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,28 +31,24 @@ on:
 jobs:
   readonly-testnet-node-sync-to-tip:
     env:
-      IMAGE_TAG: v0.6.5-rc2.1
+      GODWOKEN_PREBUILDS_IMAGE: nervos/godwoken-prebuilds:v0.6.5-rc3
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
     # - name: Download ckb-indexer-data
     #   run: |
-        # docker run --rm \
-        #   -v /ckb-indexer-data:/ckb-indexer-data \
-        #   ghcr.io/flouse/testnet-polyjuice-api:latest bash -c \
-        #   "cp /godwoken-polyman/packages/runner/db/ckb-indexer-testnet/* /ckb-indexer-data/"
-        # sudo chown -R `whoami` /ckb-indexer-data
-
-    # - name: Setup tmate session for debugging if something failed
-    #   uses: mxschmitt/action-tmate@v3
-    #   timeout-minutes: 30
+    #     docker run --rm \
+    #       -v /ckb-indexer-data:/ckb-indexer-data \
+    #       ghcr.io/flouse/testnet-polyjuice-api:latest bash -c \
+    #       "cp /godwoken-polyman/packages/runner/db/ckb-indexer-testnet/* /ckb-indexer-data/"
+    #     sudo chown -R `whoami` /ckb-indexer-data
 
     # - name: Start ckb-indexer
     #   run: |
     #     docker run -p 8116:8116 -i \
     #       -v /ckb-indexer-data:/ckb-indexer-data \
-    #       nervos/ckb-indexer:0.2.2 \
+    #       ${{ env.GODWOKEN_PREBUILDS_IMAGE }} \
     #       sh -c "RUST_LOG=info ckb-indexer -c http://3.235.223.161:18114 -s /ckb-indexer-data"
 
     # - name: Store Cache of Godwoken Testnet
@@ -70,7 +66,7 @@ jobs:
           -v `pwd`/gw-testnet-config.toml:/deploy/gw-testnet-config.toml \
           -v `pwd`/pk:/deploy/pk \
           -v `pwd`/store.db:/deploy/store.db \
-          nervos/godwoken-prebuilds:${{ env.IMAGE_TAG }} bash -c "RUST_LOG=gw=debug godwoken run -c gw-testnet-config.toml"
+          ${{ env.GODWOKEN_PREBUILDS_IMAGE }} bash -c "RUST_LOG=gw=debug godwoken run -c gw-testnet-config.toml"
       timeout-minutes: 120
 
     - name: Setup tmate session for debugging if something failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,29 @@
 name: Integration Test
 
 on:
+  workflow_dispatch:
+    inputs:
+      prebuild-image:
+        description: 'https://github.com/nervosnetwork/godwoken-docker-prebuilds'
+        required: false
+        default: 'ghcr.io/flouse/godwoken-prebuilds:latest'
+      # godwoken:
+      #   description: 'godwoken version'
+      #   required: false
+      #   default: 'The version in prebuild-image'
+      # godwoken-scripts:
+      #   description: 'godwoken-scripts version'
+      #   required: false
+      #   default: 'The version in prebuild-image'
+      # polyjuice:
+      #   description: 'polyjuice version'
+      #   required: false
+      #   default: 'The version in prebuild-image'
   push:
     branches:
     - CI
     - readonly-testnet-node-sync-to-tip
+    - manual-trigger
   pull_request:
     branches:
     - develop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,12 @@ on:
     - develop
 
 jobs:
-  # readonly-testnet-node-sync-to-tip:
-  #   env:
-  #     IMAGE_TAG: v0.6.5-rc2.1
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
+  readonly-testnet-node-sync-to-tip:
+    env:
+      IMAGE_TAG: v0.6.5-rc2.1
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
 
     # - name: Download ckb-indexer-data
     #   run: |
@@ -63,22 +63,22 @@ jobs:
     #     key: ${{ runner.os }}-cache-${{ hashFiles('**/store.db') }}
     #     ore-keys: |
     #       ${{ runner.os }}-cache-
-    # - name: readonly-testnet-node-sync-to-tip
-    #   run: |
-    #     cd configs
-    #     docker run -i -w /deploy --network host \
-    #       -v `pwd`/gw-testnet-config.toml:/deploy/gw-testnet-config.toml \
-    #       -v `pwd`/pk:/deploy/pk \
-    #       -v `pwd`/store.db:/deploy/store.db \
-    #       nervos/godwoken-prebuilds:${{ env.IMAGE_TAG }} bash -c "RUST_LOG=gw=debug godwoken run -c gw-testnet-config.toml"
-    #   timeout-minutes: 120
+    - name: readonly-testnet-node-sync-to-tip
+      run: |
+        cd configs
+        docker run -i -w /deploy --network host \
+          -v `pwd`/gw-testnet-config.toml:/deploy/gw-testnet-config.toml \
+          -v `pwd`/pk:/deploy/pk \
+          -v `pwd`/store.db:/deploy/store.db \
+          nervos/godwoken-prebuilds:${{ env.IMAGE_TAG }} bash -c "RUST_LOG=gw=debug godwoken run -c gw-testnet-config.toml"
+      timeout-minutes: 120
 
-    # - name: Setup tmate session for debugging if something failed
-    #   if: ${{ failure() }}
-    #   uses: mxschmitt/action-tmate@v3
-    #   timeout-minutes: 30
+    - name: Setup tmate session for debugging if something failed
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 30
 
-
+  # Run integration-tests base on Godowoken-Kicker services
   devnet:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -2,55 +2,91 @@
 
 This repository contains integration tests that test [Godwoken](https://github.com/nervosnetwork/godwoken).
 
-## Prerequisites
+## How to create a godwoken integration-test workflow
+
+### Prerequisites
+Admin rights(`actions:write` permission) to this repository is required.
+
+### 2 Methods
+* Use the `Run workflow` button on the Action tab to easily trigger a run
+    <img src="https://user-images.githubusercontent.com/1297478/135286697-ae13f1af-40ae-4e97-9bc7-28799d6fd740.png " alt="run workflow" width="360"/>
+
+    We can specify the inputs of a [workflow dispatch](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch):
+
+      a. The prebuild image including Godwoken related bins (* required). Pick the right tag from:
+        
+       - https://hub.docker.com/r/nervos/godwoken-prebuilds
+       - https://github.com/Flouse/godwoken-docker-prebuilds/pkgs/container/godwoken-prebuilds
+
+      b. The special versions of Godwoken, Godwoken-scripts, or Polyjuice we want to test with (optional)
+
+* Use the `dispatches` REST API endpoint to manually trigger a GitHub Action workflow run
+
+    <code><span class="color-bg-info-inverse color-text-inverse rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches</code>
+
+    See also: [GitHub Doc - Create a workflow dispatch event](https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event)
+
+    Example:
+    ```sh
+    curl -u {username}:{$token} \
+        -X POST \
+        -H "Accept: application/vnd.github.v3+json" \
+        https://api.github.com/repos/nervosnetwork/godwoken-tests/actions/workflows/test.yml/dispatches \
+        -d '{"ref":"develop","inputs":{"gw_prebuild_image_name":"ghcr.io/flouse/godwoken-prebuilds","gw_prebuild_image_tag":"v0.6.5-rc3"}}'
+    ```
+    > Set up a variable for token to avoid leaving your token in shell history, which should be avoided.
+
+## Running tests locally
+
+### Prerequisites
 
 * [Docker](https://docs.docker.com/get-docker/), [docker-compose](https://docs.docker.com/compose/install/), [`Node.js` v14+](https://nodejs.org) and [`Yarn`](https://yarnpkg.com) are required.
 * Before tests can be run locally, a godwoken dev chain should be runing.
 [Godwoken-Kicker](https://github.com/RetricSu/godwoken-kicker) would be a good choice to start godwoken-polyjuice chain with one line command.
 
-## Running tests locally
+### Steps
 
 1. Fetch the source code:
-```sh
-git clone --recursive https://github.com/nervosnetwork/godwoken-tests.git
-cd godwoken-tests
-```
+    ```sh
+    git clone --recursive https://github.com/nervosnetwork/godwoken-tests.git
+    cd godwoken-tests
+    ```
 
 2. Update [`nervos/godwoken-prebuilds`](https://hub.docker.com/r/nervos/godwoken-prebuilds/tags?page=1&ordering=last_updated) docker image to the version you expected.
-```sh
-# edit this line in `kicker/docker/.build.mode.env`
-DOCKER_PREBUILD_IMAGE_TAG=<the tag you expected>
-```
+    ```sh
+    # edit this line in `kicker/docker/.build.mode.env`
+    DOCKER_PREBUILD_IMAGE_TAG=<the tag you expected>
+    ```
 
 3. Start Godwoken-Kicker
-```sh
-cd kicker
-make init && make start
-```
+    ```sh
+    cd kicker
+    make init && make start
+    ```
 
 4. Generate a devnet envfile from [godwoken-config.toml](kicker/workspace/config.toml)
-```sh
-cd tools
-yarn install
-cd packages/tools
-yarn generate-envfile
-```
+    ```sh
+    cd tools
+    yarn install
+    cd packages/tools
+    yarn generate-envfile
+    ```
 
 5. Run test cases using `devnet.env`
-```sh
-cd testcases/godwoken-polyjuice-compatibility-examples
-yarn install && yarn compile
-ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/box-proxy.ts
-ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/multi-sign-wallet.ts
-ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/multicall.ts
-ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/create2.ts
-ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/stable-swap-3-pool.ts
+    ```sh
+    cd testcases/godwoken-polyjuice-compatibility-examples
+    yarn install && yarn compile
+    ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/box-proxy.ts
+    ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/multi-sign-wallet.ts
+    ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/multicall.ts
+    ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/create2.ts
+    ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/stable-swap-3-pool.ts
 
-cd testcases/pancakeswap-contracts-godwoken
-yarn && yarn compile
-ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/deploy.ts
-```
+    cd testcases/pancakeswap-contracts-godwoken
+    yarn && yarn compile
+    ENV_PATH=../../tools/packages/tools/configs/devnet.env yarn ts-node ./scripts/deploy.ts
+    ```
 
 New test cases could be added into `testcases` directory
 
-**Note**: If you boot a new godwoken chain, you should `generate-envfile` again.
+> **Note**: If you boot a new godwoken chain, you should `generate-envfile` again.

--- a/TODO
+++ b/TODO
@@ -1,1 +1,2 @@
-- Add Godwoken Kicker as a submodule
+* timeout actions
+  - https://github.com/Flouse/godwoken/runs/3721851298?check_suite_focus=true#step:14:40

--- a/configs/gw-testnet-config.toml
+++ b/configs/gw-testnet-config.toml
@@ -66,8 +66,8 @@ args = '0x213743d13048e9f36728c547ab736023a7426e15a3d7d1c82f43ec3b5f266df2'
 skipped_invalid_block_list=["0x4e631850ffbd2259845f332bb32e3d46f288009269f9b48fb5b40266b0bc25d4"]
 
 [rpc_client]
-indexer_url = 'http://3.235.223.161:18116'
-ckb_url = 'http://3.235.223.161:18114'
+indexer_url = 'https://testnet.ckb.dev/indexer'
+ckb_url = 'https://testnet.ckb.dev/rpc'
 
 [rpc_server]
 listen = '0.0.0.0:8119'

--- a/configs/gw-testnet-config.toml
+++ b/configs/gw-testnet-config.toml
@@ -66,8 +66,8 @@ args = '0x213743d13048e9f36728c547ab736023a7426e15a3d7d1c82f43ec3b5f266df2'
 skipped_invalid_block_list=["0x4e631850ffbd2259845f332bb32e3d46f288009269f9b48fb5b40266b0bc25d4"]
 
 [rpc_client]
-indexer_url = 'https://testnet.ckb.dev/indexer'
-ckb_url = 'https://testnet.ckb.dev/rpc'
+indexer_url = 'https://testnet.ckbapp.dev/indexer'
+ckb_url = 'https://testnet.ckbapp.dev/rpc'
 
 [rpc_server]
 listen = '0.0.0.0:8119'

--- a/docs/public-nodes.md
+++ b/docs/public-nodes.md
@@ -19,10 +19,12 @@
 ## CKB Testnet Aggron
 
 ### Node RPC
+- CKB2021: https://testnet.ckbapp.dev/rpc
 - https://testnet.ckb.dev/
 - https://testnet.ckb.dev/rpc
 
 ### Indexer RPC
+- CKB2021: https://testnet.ckbapp.dev/indexer
 - https://testnet.ckb.dev/indexer
 
 ## Limit

--- a/docs/public-nodes.md
+++ b/docs/public-nodes.md
@@ -1,0 +1,30 @@
+# Public Nodes
+
+## Godwoken
+
+### [Testnet Web3 RPC](https://github.com/nervosnetwork/godwoken-testnet#web3-rpc)
+- http://godwoken-testnet-web3-rpc.ckbapp.dev
+
+
+## CKB Mainnet Lina
+
+### Node RPC
+- https://mainnet.ckb.dev/
+- https://mainnet.ckb.dev/rpc
+
+### Indexer RPC
+- https://mainnet.ckb.dev/indexer
+
+
+## CKB Testnet Aggron
+
+### Node RPC
+- https://testnet.ckb.dev/
+- https://testnet.ckb.dev/rpc
+
+### Indexer RPC
+- https://testnet.ckb.dev/indexer
+
+## Limit
+- rate: 20 req/s
+- burst: 20 req/s


### PR DESCRIPTION
Now, we can create workflows that are manually triggered with the new workflow_dispatch event.


### Prerequisites
Admin rights(`actions:write` permission) to this repository is required.

### 2 Methods
* Use the `Run workflow` button on the Action tab to easily trigger a run
    <img src="https://user-images.githubusercontent.com/1297478/135286697-ae13f1af-40ae-4e97-9bc7-28799d6fd740.png " alt="run workflow" width="360"/>

    We can specify the inputs of a [workflow dispatch](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch):

      a. The prebuild image including Godwoken related bins (* required). Pick the right tag from:
        
       - https://hub.docker.com/r/nervos/godwoken-prebuilds
       - https://github.com/Flouse/godwoken-docker-prebuilds/pkgs/container/godwoken-prebuilds

      b. The special versions of Godwoken, Godwoken-scripts, or Polyjuice we want to test with (optional)

* Use the `dispatches` REST API endpoint to manually trigger a GitHub Action workflow run

    <code><span class="color-bg-info-inverse color-text-inverse rounded-1 px-2 py-1" style="text-transform: uppercase">post</span> /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches</code>

    See also: [GitHub Doc - Create a workflow dispatch event](https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event)

    Example:
    ```sh
    curl -u {username}:{$token} \
        -X POST \
        -H "Accept: application/vnd.github.v3+json" \
        https://api.github.com/repos/nervosnetwork/godwoken-tests/actions/workflows/test.yml/dispatches \
        -d '{"ref":"develop","inputs":{"gw_prebuild_image_name":"ghcr.io/flouse/godwoken-prebuilds","gw_prebuild_image_tag":"v0.6.5-rc3"}}'
    ```
    > Set up a variable for token to avoid leaving your token in shell history, which should be avoided.