### PR TITLE
chore: lock default kicker_ref

### DIFF
--- a/.github/workflows/reusable-integration-test-v1.yml
+++ b/.github/workflows/reusable-integration-test-v1.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         repository: RetricSu/godwoken-kicker
         # If this workflow is not triggered by workflow_call event, inputs.kicker_ref is empty.
-        ref: ${{ inputs.kicker_ref || 'compatibility-changes' }}
+        ref: ${{ inputs.kicker_ref || 'd25630cc74b853bd9dfd4be89bf0d0d7077f0bee' }}
         path: kicker
         submodules: 'recursive'
 


### PR DESCRIPTION
Godwoken Kicker is under active development, so we lock a stable default version to avoid uncertain test results.