### PR TITLE
chore: wait confirm for tx

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -46,6 +46,9 @@ module.exports = {
       hardfork: "berlin"
     }
   },
+  mocha: {
+    timeout: 1800000 // 30 minutes
+  },
   solidity: {
     compilers: [
       { // for polyjuice contracts

--- a/contracts/test/Calc.js
+++ b/contracts/test/Calc.js
@@ -8,7 +8,8 @@ describe("Calc contract", function () {
         await contract.deployed()
 
         //Set data
-        await contract.store(256);
+        const i = await contract.store(256);
+        await i.wait();
 
         //Read data
         const number = await contract.retrieve();

--- a/contracts/test/HeadTail.js
+++ b/contracts/test/HeadTail.js
@@ -99,9 +99,10 @@ describe('HeadTail', () => {
 
             expect(await contract.userOneAddress()).to.be.equal(userOne.address);
 
-            await contract.connect(userTwo).depositUserTwo(true, {
+            const tx = await contract.connect(userTwo).depositUserTwo(true, {
                 value: BET_VALUE
             });
+            await tx.wait();
 
             expect(await contract.userTwoAddress()).to.be.equal(userTwo.address);
         });
@@ -125,15 +126,17 @@ describe('HeadTail', () => {
 
             expect(await contract.userOneAddress()).to.be.equal(userOne.address);
 
-            await contract.connect(userTwo).depositUserTwo(true, {
+            const tx = await contract.connect(userTwo).depositUserTwo(true, {
                 gasPrice: 0,
                 value: BET_VALUE
             });
+            await tx.wait();
 
-            await contract.revealUserOneChoice(userOneChoice, userOneChoiceSecret, {
+            const tx1 = await contract.revealUserOneChoice(userOneChoice, userOneChoiceSecret, {
                 gasPrice: 0,
                 gasLimit: 10000000
             });
+            await tx1.wait();
 
             expect(await getBalanceAsString(userOne.address)).to.be.equal(
                 startingUserOneBalance.sub(BET_VALUE).toString(),

--- a/contracts/test/SisyhusGamble.js
+++ b/contracts/test/SisyhusGamble.js
@@ -32,7 +32,7 @@ describe("SisyphusGamble", function () {
       1, // startingPrize
       1, // minGamble
       1, // weight
-      2, // gamblingBlocks
+      4, // gamblingBlocks
     );
     await tx1.wait();
     expect(await erc20.balanceOf(sender.address)).to.equal(balanceOfSender - 1);

--- a/contracts/test/SisyhusGamble.js
+++ b/contracts/test/SisyhusGamble.js
@@ -26,13 +26,15 @@ describe("SisyphusGamble", function () {
     expect(balanceOfSender).equals(10000);
 
     console.log("Start a new sisyphus gamble");
-    await erc20.approve(sisyphusGambleVenues.address, 1);
-    await sisyphusGambleVenues.newSisyphusGamble(erc20.address,
+    const tx = await erc20.approve(sisyphusGambleVenues.address, 1);
+    tx.wait();
+    const tx1 = await sisyphusGambleVenues.newSisyphusGamble(erc20.address,
       1, // startingPrize
       1, // minGamble
       1, // weight
       2, // gamblingBlocks
     );
+    await tx1.wait();
     expect(await erc20.balanceOf(sender.address)).to.equal(balanceOfSender - 1);
     console.log(`  Getting Sisyphus Gamble Venues...`);
     let gameList = await sisyphusGambleVenues.getSisyphusGambleVenues();
@@ -42,12 +44,17 @@ describe("SisyphusGamble", function () {
 
     console.log("SisyphusGambling...");
     let gambleContract = await ethers.getContractAt("SisyphusGamble", sisyphusGambleAddress);
-    await erc20.approve(sisyphusGambleAddress, 3);
-    await gambleContract.gamble(1);
+    const tx2 = await erc20.approve(sisyphusGambleAddress, 3);
+    await tx2.wait();
+    const tx3 = await gambleContract.gamble(1);
+    await tx3.wait();
+    
     expect(await gambleContract.totalPrize()).eq(2);
-    await gambleContract.gamble(1);
+    const tx4 = await gambleContract.gamble(1);
+    await tx4.wait();
     expect(await gambleContract.totalPrize()).eq(3);
-    await gambleContract.gamble(1);
+    const tx5 = await gambleContract.gamble(1);
+    await tx5.wait();
     expect(await gambleContract.totalPrize()).eq(4);
 
     console.log(">> Claim Prize");

--- a/contracts/test/SisyhusGamble.js
+++ b/contracts/test/SisyhusGamble.js
@@ -27,7 +27,7 @@ describe("SisyphusGamble", function () {
 
     console.log("Start a new sisyphus gamble");
     const tx = await erc20.approve(sisyphusGambleVenues.address, 1);
-    tx.wait();
+    await tx.wait();
     const tx1 = await sisyphusGambleVenues.newSisyphusGamble(erc20.address,
       1, // startingPrize
       1, // minGamble

--- a/contracts/test/Token.js
+++ b/contracts/test/Token.js
@@ -61,7 +61,8 @@ describe("Token contract", function () {
   describe("Transactions", function () {
     it("Should transfer tokens between accounts", async function () {
       // Transfer 50 tokens from owner to addr1
-      await hardhatToken.transfer(addr1.address, 50);
+      const tx = await hardhatToken.transfer(addr1.address, 50);
+      await tx.wait();
       const addr1Balance = await hardhatToken.balanceOf(addr1.address);
       expect(addr1Balance).to.equal(50);
     });
@@ -70,8 +71,9 @@ describe("Token contract", function () {
       const initialOwnerBalance = await hardhatToken.balanceOf(owner.address);
 
       // Transfer 100 tokens from owner to addr1.
-      await hardhatToken.transfer(addr1.address, 100);
-
+      const tx = await hardhatToken.transfer(addr1.address, 100);
+      await tx.wait();
+      
       // Check balances.
       const finalOwnerBalance = await hardhatToken.balanceOf(owner.address);
       expect(finalOwnerBalance).to.equal(initialOwnerBalance.sub(100));


### PR DESCRIPTION
ether.js use tx.wait() (default to 1 block) to confirm the tx. currently, we didn't wait for write call to interact with contract. this only works under instant-finality feature. 