### PR TITLE
chore: kicker ps at post stage

### DIFF
--- a/.github/workflows/integration-test-v1-trigger.yml
+++ b/.github/workflows/integration-test-v1-trigger.yml
@@ -3,7 +3,7 @@ name: Run Integration Test v1
 on:
   push:
     branches:
-    - 'v1'
+    - 'v1*'
     - 'develop'
   pull_request:
 

--- a/.github/workflows/reusable-integration-test-v1.yml
+++ b/.github/workflows/reusable-integration-test-v1.yml
@@ -273,6 +273,7 @@ jobs:
       if: always()
       working-directory: kicker/docker
       run: |
+        docker-compose ps
         docker-compose logs --tail 66
         docker-compose logs > /tmp/kicker.log
     - name: Archive logs

--- a/.github/workflows/reusable-integration-test-v1.yml
+++ b/.github/workflows/reusable-integration-test-v1.yml
@@ -40,14 +40,6 @@ on:
         description: 'Log level'
         required: false
         default: 'INFO'
-  push:
-    branches:
-    - 'v1*'
-    - 'develop'
-  pull_request_target:
-    branches:
-    - 'v1*'
-    - 'develop'
 
 jobs:
   # Run integration-tests on devnet_v1 deployed by Godowoken-Kicker


### PR DESCRIPTION
It seems GitHub Actions runner may kill our services.
I add a log printing the status of kicker services.