### PR TITLE
refactor(failedTx): remove `gasPrice` in failedTx test case

### DIFF
--- a/contracts/contracts/RevertHandling.sol
+++ b/contracts/contracts/RevertHandling.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8;
 contract RevertHandling {
     string public message;
 
+    event SetMsg(string message, uint256 amount);
+
     function getMsg() public view returns (string memory) {
         return message;
     }
@@ -10,5 +12,7 @@ contract RevertHandling {
     function setMsg(uint success, string memory _message) public payable {
         require(success == 1, "failed to set message");
         message = _message;
+
+        emit SetMsg(message, msg.value);
     }
 }


### PR DESCRIPTION
1. remove gasPrice related settings and tests
2. provide clearer asserts by adding event to the contract

But the change 2 actually caused the average time cost of the test case increased by `1500 ms`. 

Over all I think the down side it is acceptable, but maybe we should take a better look at the time cost problem when we refactor the whole test project later, using TypeScript.