### PR TITLE
docs: improve `account-faucet`'s README

### DIFF
--- a/scripts/account-faucet/README.md
+++ b/scripts/account-faucet/README.md
@@ -1,28 +1,44 @@
 # Account-Faucet
 
-## What is it?
-Account-Faucet is a CLI tool to help you claim faucet to your Godwoken layer 2 accounts.
+## What is this?
+This is Account-Faucet, a CLI tool to claim faucet for your Godwoken layer 2 accounts.
 
-You can pass a `CKB private key`, the CLI will automatically calculate the layer 2 deposit address, and then claim faucet to the address. Or you can pass your `ETH address`, the CLI will do the same thing for you.
+## Why should I use it?
+Originally, when you need to claim faucet to your Godwoken layer 2 wallet, you need to go through all these steps:
+1. Go to [Faucet](https://faucet.nervos.org) page and claim faucet to your CKB account
+2. Go to [Godwoken Bridge](https://testnet.bridge.godwoken.io/) and deposit CKB to your Godwoken layer 2 account
 
-## Usage
-Install dependencies
+The steps above are fairly simple, but not so easy if you do it manually, every day. 
+With this CLI tool, you can actually finish the entire process in one command, which can save you a lot of time. 
+
+All you need to prepare is your `ETH address`, or your `CKB private key`.
+
+## Ready
+1. Go to `Account-Faucet` folder in `Godwoken-Tests`:
+```bash
+$ cd scripts/account-faucet
+```
+2. Install dependencies:
 ```bash
 $ npm install
 ```
-Claim faucet, using your `CKB Layer 1 Private Key`
-```bash
-$ npm run faucet -- claim -p <CKB_PRIVATE_KEY>
-```
-Claim faucet, using your `ETH Address`
+
+## Claim faucet
+
+### Claim with ETH Address
+If you're more familiar with your `ETH address`, we recommend you to use this command: 
 ```bash
 $ npm run faucet -- claim -e <ETH_ADDRESS>
 ```
-When Claiming with `ETH Address`, you can also pass your `CKB Address`
+
+### Claim with CKB Private Key
+If you prefer to claim faucet with your `CKB Layer 1 Private Key`:
 ```bash
-$ npm run faucet -- claim -e <ETH_ADDRESS> - c <CKB_ADDRESS>
+$ npm run faucet -- claim -p <CKB_PRIVATE_KEY>
 ```
-For more options, you can check for help
+
+### Other command options
+For more options, you can check with the `--help` command:
 ```bash
-$ npm run faucet -- -h
+$ npm run faucet -- claim -h
 ```


### PR DESCRIPTION
The README.md file of `account-faucet` script has been refactored:
- The `claim -e <ETH_ADDRESS>` command has been moved to the top of the section, since we recommend users to claim faucet with their `ETH Address`, instead with their `CKB Private Key`
- The `ckbAddress` option has been removed from the docs