### PR TITLE
feat: `get-l2-address` util command in account-faucet

### DIFF
--- a/scripts/account-faucet/README.md
+++ b/scripts/account-faucet/README.md
@@ -42,3 +42,26 @@ For more options, you can check with the `--help` command:
 ```bash
 $ npm run faucet -- claim -h
 ```
+
+## Get Layer2 Deposit Address
+
+### Calculate with ETH Address or CKB Private Key
+This is an util command to calculate the Layer2 Deposit Address.   
+It's a very similar command to the `claim` command, you can pass a ETH address:
+```bash
+$ npm run faucet -- get-l2-address -e <ETH_ADDRESS>
+```
+Or pass a CKB Private Key:
+```bash
+$ npm run faucet -- get-l2-address -p <CKB_PRIVATE_KEY>
+```
+
+### Address on different network
+You can use `-n` or `--network` option to calculate the Layer2 Deposit Address on different network:
+```bash
+$ npm run faucet -- get-l2-address -e <ETH_ADDRESS> -n <NETWORK>
+```
+
+Right now the supported networks are:
+- mainnet_v1
+- testnet_v1

--- a/scripts/account-faucet/src/config.ts
+++ b/scripts/account-faucet/src/config.ts
@@ -1,21 +1,28 @@
 import { predefined } from '@ckb-lumos/config-manager';
 
-const environment = {
-  rpc: 'https://godwoken-testnet-v1.ckbapp.dev',
-  lumosConfig: predefined.AGGRON4,
-  // NOT USED YET
-  accounts: [
-    '1390c30e5d5867ee7246619173b5922d3b04009cab9e9d91e14506231281a997',
-    '2dc6374a2238e414e51874f514b0fa871f8ce0eb1e7ecaa0aed229312ffc91b0',
-    'dd50cac37ec6dd12539a968c1a2cbedda75bd8724f7bcad486548eaabb87fc8b',
-  ],
-};
-
-// This function is used to handle external accounts (passing from CI or else)
-// NOT USED YET
-function searchAccounts(prefix: string, env: NodeJS.ProcessEnv) {
-  const keys = Object.keys(env).filter(key => new RegExp(`${prefix}(\d){0,}`).test(key));
-  return keys.map(key => env[key]);
+type ValueOf<T> = T[keyof T];
+export enum Network {
+  MainnetV1 = 'mainnet_v1',
+  TestnetV1 = 'testnet_v1',
+}
+export interface NetworkConfig {
+  rpc: string;
+  lumos: {
+    config: ValueOf<typeof predefined>,
+  };
 }
 
-export default environment;
+export const networks : Record<Network, NetworkConfig> = {
+  [Network.TestnetV1]: {
+    rpc: 'https://godwoken-testnet-v1.ckbapp.dev',
+    lumos: {
+      config: predefined.AGGRON4
+    },
+  },
+  [Network.MainnetV1]: {
+    rpc: 'https://v1.mainnet.godwoken.io/rpc',
+    lumos: {
+      config: predefined.LINA,
+    }
+  },
+};

--- a/scripts/account-faucet/src/faucet/address.ts
+++ b/scripts/account-faucet/src/faucet/address.ts
@@ -1,4 +1,4 @@
-import config from '../config';
+import { NetworkConfig } from '../config';
 import { GodwokenWeb3 } from '../godwoken/web3';
 import { generateDepositLock } from '../godwoken/deposit';
 import { utils, Hash, Script, HexString, Address } from '@ckb-lumos/base';
@@ -10,16 +10,11 @@ import crypto from 'crypto';
 // https://github.com/nervosnetwork/godwoken/blob/d6c98d8f8a199b6ec29bc77c5065c1108220bb0a/crates/common/src/builtins.rs#L5
 export const ETH_REGISTRY_ID: number = 2;
 
-// https://github.com/nervosnetwork/lumos/blob/develop/packages/config-manager/src/predefined.ts#L71-L123
-export const lumosOptions = {
-  config: config.lumosConfig,
-};
-
-export async function encodeLayer2DepositAddress(gw: GodwokenWeb3, ckbAddress: Address, ethAddress: HexString): Promise<Address> {
+export async function encodeLayer2DepositAddress(config: NetworkConfig, gw: GodwokenWeb3, ckbAddress: Address, ethAddress: HexString): Promise<Address> {
   const { nodeInfo } = await gw.getNodeInfo();
   const gwRollupTypeHash: Hash = await gw.getRollupTypeHash();
 
-  const ownerLock: Script = parseAddress(ckbAddress, lumosOptions);
+  const ownerLock: Script = parseAddress(ckbAddress, config.lumos);
   const ownerLockHash: Hash = utils.computeScriptHash(ownerLock);
 
   const layer2Lock: Script = {
@@ -33,27 +28,27 @@ export async function encodeLayer2DepositAddress(gw: GodwokenWeb3, ckbAddress: A
     nodeInfo.gwScripts.deposit.typeHash
   );
 
-  return encodeToAddress(depositLock, lumosOptions);
+  return encodeToAddress(depositLock, config.lumos);
 }
 
-export async function privateKeyToLayer2DepositAddress(gw: GodwokenWeb3, privateKey: HexString): Promise<Address> {
-  const ckbAddress = privateKeyToCkbAddress(privateKey);
+export async function privateKeyToLayer2DepositAddress(config: NetworkConfig, gw: GodwokenWeb3, privateKey: HexString): Promise<Address> {
+  const ckbAddress = privateKeyToCkbAddress(config, privateKey);
   const ethAddress = privateKeyToEthAddress(privateKey);
 
-  return encodeLayer2DepositAddress(gw, ckbAddress, ethAddress.toLocaleLowerCase());
+  return encodeLayer2DepositAddress(config, gw, ckbAddress, ethAddress.toLocaleLowerCase());
 }
 
-export function privateKeyToCkbAddress(privateKey: HexString): Address {
+export function privateKeyToCkbAddress(config: NetworkConfig, privateKey: HexString): Address {
   const publicKey = key.privateToPublic(privateKey);
   const publicKeyHash = key.publicKeyToBlake160(publicKey);
-  const scriptConfig = lumosOptions.config.SCRIPTS.SECP256K1_BLAKE160!;
+  const scriptConfig = config.lumos.config.SCRIPTS.SECP256K1_BLAKE160!;
   const script = {
     code_hash: scriptConfig.CODE_HASH,
     hash_type: scriptConfig.HASH_TYPE,
     args: publicKeyHash,
   };
 
-  return encodeToAddress(script, lumosOptions);
+  return encodeToAddress(script, config.lumos);
 }
 
 export function privateKeyToEthAddress(privateKey: HexString): HexString {

--- a/scripts/account-faucet/src/faucet/command.ts
+++ b/scripts/account-faucet/src/faucet/command.ts
@@ -1,10 +1,12 @@
-import config from '../config';
+import { Network, networks } from '../config';
 import { Command } from 'commander';
 import { Address, HexString } from '@ckb-lumos/base';
 import { GodwokenWeb3 } from '../godwoken/web3';
 import { claimFaucetForCkbAddress } from './faucet';
 import { encodeLayer2DepositAddress, privateKeyToLayer2DepositAddress, toAddress, toHexString } from './address';
 
+// Default faucet refund address
+// This is also the address that sends the faucet transaction
 const defaultCkbAddress = 'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqflz4emgssc6nqj4yv3nfv2sca7g9dzhscgmg28x';
 
 export interface FaucetCommand {
@@ -27,18 +29,57 @@ export function setupFaucetCommand(program: Command) {
 
 export async function runFaucet(params: FaucetCommand) {
   const { privateKey, ckbAddress, ethAddress, rpc } = params;
-  if (!privateKey && !(ckbAddress && ethAddress)) {
-    throw new Error('provide either `privateKey` or `ckbAddress` and `ethAddress`');
+  if (!privateKey && !ethAddress) {
+    throw new Error('provide either `privateKey` or `ethAddress`');
   }
 
+  const config = networks[Network.TestnetV1];
   const gw = new GodwokenWeb3(rpc || config.rpc);
 
   let depositAddress: Address;
   if (privateKey) {
-    depositAddress = await privateKeyToLayer2DepositAddress(gw, toHexString(privateKey));
+    depositAddress = await privateKeyToLayer2DepositAddress(config, gw, toHexString(privateKey));
   } else {
-    depositAddress = await encodeLayer2DepositAddress(gw, toAddress(ckbAddress!), toHexString(ethAddress!));
+    depositAddress = await encodeLayer2DepositAddress(config, gw, toAddress(ckbAddress!), toHexString(ethAddress!));
   }
 
   await claimFaucetForCkbAddress(depositAddress);
+}
+
+export function setupCalculateLayer2AddressCommand(program: Command) {
+  program
+    .command('get-l2-address')
+    .description('calculate layer 2 deposit address')
+    .option('-p, --private-key <privateKey>', '[HexString] ckb private key')
+    .option('-e --eth-address <ethAddress>', '[HexString] eth address (optional)')
+    .option('-c --ckb-address <ckbAddress>', '[Address] ckb address (optional)', defaultCkbAddress)
+    .option('-n, --network <network>', '[string] network name', Network.TestnetV1)
+    .action(runCalculateLayer2Address);
+}
+
+export interface CalculateLayer2AddressCommand {
+  privateKey?: HexString | string;
+  ckbAddress?: HexString | string;
+  ethAddress?: HexString | string;
+  network: Network;
+}
+
+async function runCalculateLayer2Address(params: CalculateLayer2AddressCommand) {
+  const { privateKey, ckbAddress, ethAddress, network } = params;
+  if (!privateKey && !ethAddress) {
+    throw new Error('provide either `privateKey` or `ethAddress`');
+  }
+
+  const config = networks[network];
+  const gw = new GodwokenWeb3(config.rpc);
+
+  if (privateKey) {
+    console.log(
+      await privateKeyToLayer2DepositAddress(config, gw, toHexString(privateKey))
+    );
+  } else {
+    console.log(
+      await encodeLayer2DepositAddress(config, gw, toAddress(ckbAddress!), toHexString(ethAddress!))
+    );
+  }
 }

--- a/scripts/account-faucet/src/index.ts
+++ b/scripts/account-faucet/src/index.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { setupFaucetCommand } from './faucet/command';
+import { setupCalculateLayer2AddressCommand, setupFaucetCommand } from './faucet/command';
 
 async function main() {
   const program = new Command();
@@ -7,6 +7,8 @@ async function main() {
 
   // faucet
   setupFaucetCommand(program);
+  // calculate layer 2 deposit address
+  setupCalculateLayer2AddressCommand(program);
   
   program.parse();
 }


### PR DESCRIPTION
Provide chagnes:
- Network options `mainnet_v1` and `testnet_v1` (right now it only works for the `get-l2-address` command)
- New util command `get-l2-address` to calculate your layer 2 deposit address