### PR TITLE
fix: disable `autoCreateAccount` on gw_mainnet_v1 testing

### DIFF
--- a/contracts/test/autoCreateAccount.js
+++ b/contracts/test/autoCreateAccount.js
@@ -2,10 +2,15 @@ const hardhat = require("hardhat")
 const { assert } = require("chai")
 const { RPC } = require("@ckb-lumos/toolkit")
 const { ERC20_BYTECODE, ERC20_ABI } = require("../lib/sudtErc20Proxy")
+const { isGwMainnetV1 } = require("../utils/network")
 
 const { ethers } = hardhat;
 
 describe("AutoCreateAccount", function () {
+  if (isGwMainnetV1()) {
+    return;
+  }
+
   let rpc
   let owner
   let token


### PR DESCRIPTION
This test case should be disalbed when testing on gw_mainnet_v1.