### PR TITLE
chore: run Contract Tests every 12 hours

### DIFF
--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -14,7 +14,7 @@ on:
   # Note: GitHub Actions does not support the non-standard syntax @yearly, @monthly, @weekly, @daily, @hourly, and @reboot.
   # You can use crontab guru (https://crontab.guru/) to help generate your cron syntax and confirm what time it will run.
   # To help you get started, there is also a list of crontab guru examples (https://crontab.guru/examples.html).
-  - cron:  '50 */6 * * *' # every 6 hour
+  - cron:  '50 */12 * * *' # every 12 hour
 
 jobs:
   check-secrets:


### PR DESCRIPTION
Reduce the frequency of testing to reduce the probability of [insufficient balance](https://github.com/nervosnetwork/godwoken-tests/runs/7767317358?check_suite_focus=true#step:7:145).
