### PR TITLE
chore: tune `maxDepth` of RecursiveCall test case

### DIFF
--- a/contracts/test/RecursiveCall.js
+++ b/contracts/test/RecursiveCall.js
@@ -13,7 +13,7 @@ describe("Recursion Contract", function () {
     const recurContract = await contractFact.deploy();
     await recurContract.deployed();
 
-    const maxDepth = 36
+    const maxDepth = 35;
     for (let i = 1; i <= maxDepth; i++) {
       let pureSumLoop = await recurContract.pureSumLoop(i);
       let sum = await recurContract.sum(i);


### PR DESCRIPTION
fix VM error memory error: write on executable page

## References
- https://github.com/Flouse/godwoken-polyjuice/actions/runs/3209545439/jobs/5246350958#step:23:1041
- https://github.com/nervosnetwork/godwoken-polyjuice/pull/88