### PR TITLE
refactor: rename organization used in CI

### DIFF
--- a/.github/workflows/account-faucet.yml
+++ b/.github/workflows/account-faucet.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-secrets:
-    if: github.repository == 'nervosnetwork/godwoken-tests'
+    if: github.repository == 'godwokenrises/godwoken-tests'
     runs-on: ubuntu-latest
     outputs:
       available: ${{ steps.check.outputs.available }}

--- a/.github/workflows/alphanet_openzeppelin_test.yml
+++ b/.github/workflows/alphanet_openzeppelin_test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   contract-tests:
     runs-on: ubuntu-latest
-    if: github.repository == 'nervosnetwork/godwoken-tests'
+    if: github.repository == 'godwokenrises/godwoken-tests'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   check-secrets:
-    if: github.repository == 'nervosnetwork/godwoken-tests'
+    if: github.repository == 'godwokenrises/godwoken-tests'
     runs-on: ubuntu-latest
     outputs:
       available: ${{ steps.check.outputs.available }}

--- a/.github/workflows/deposit_and_withdraw.yml
+++ b/.github/workflows/deposit_and_withdraw.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         net: ['alphanet', 'testnet', 'testnet_v1']
     runs-on: ubuntu-latest
-    if: github.repository == 'nervosnetwork/godwoken-tests'
+    if: github.repository == 'godwokenrises/godwoken-tests'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/fee-test.yml
+++ b/.github/workflows/fee-test.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         net: ['alphanet', 'testnet']
     runs-on: ubuntu-latest
-    if: github.repository == 'nervosnetwork/godwoken-tests'
+    if: github.repository == 'godwokenrises/godwoken-tests'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/godwoken-tests.yml
+++ b/.github/workflows/godwoken-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   godwoken-tests:
-    uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
+    uses: godwokenrises/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
     with:
       extra_github_env: |
         GODWOKEN_TESTS_REPO=${{ github.repository }}

--- a/.github/workflows/integration-test-chat-bot-v1.yml
+++ b/.github/workflows/integration-test-chat-bot-v1.yml
@@ -437,7 +437,7 @@ jobs:
 
   run-integration-test:
     needs: component-info
-    uses: nervosnetwork/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
+    uses: godwokenrises/godwoken-tests/.github/workflows/reusable-integration-test-v1.yml@develop
     with:
       extra_github_env: |
         ${{ needs.component-info.outputs.extra_github_env }}

--- a/.github/workflows/reusable-integration-test-v0.yml
+++ b/.github/workflows/reusable-integration-test-v0.yml
@@ -17,19 +17,19 @@ on:
         required: false
         type: string
       godwoken_ref:
-        description: 'The reference of https://github.com/nervosnetwork/godwoken.git'
+        description: 'The reference of https://github.com/godwokenrises/godwoken.git'
         required: false
         type: string
       gw_scripts_ref:
-        description: 'The reference of https://github.com/nervosnetwork/godwoken-scripts.git'
+        description: 'The reference of https://github.com/godwokenrises/godwoken-scripts.git'
         required: false
         type: string
       polyjuice_ref:
-        description: 'The reference of https://github.com/nervosnetwork/godwoken-polyjuice.git'
+        description: 'The reference of https://github.com/godwokenrises/godwoken-polyjuice.git'
         required: false
         type: string
       web3_ref:
-        description: 'The reference of https://github.com/nervosnetwork/godwoken-web3.git'
+        description: 'The reference of https://github.com/godwokenrises/godwoken-web3.git'
         required: false
         type: string
       log-level:
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout godwoken-tests
       uses: actions/checkout@v3
       with:
-        repository: nervosnetwork/godwoken-tests
+        repository: godwokenrises/godwoken-tests
         ref: v0
         submodules: 'recursive'
     - name: Checkout Kicker # multiple repos (nested)

--- a/.github/workflows/reusable-integration-test-v1.yml
+++ b/.github/workflows/reusable-integration-test-v1.yml
@@ -17,7 +17,7 @@ on:
       #
       #   ```yaml
       #   extra_github_env: |
-      #     GODWOKEN_TESTS_REPO=keroro520/godwoken-tests # default is nervosnetwork/godwoken-tests
+      #     GODWOKEN_TESTS_REPO=keroro520/godwoken-tests # default is godwokenrises/godwoken-tests
       #     GODWOKEN_TESTS_REF=helloworld # default is develop
       #     GODWOKEN_KICKER_REPO=keroro520/godwoken-kicker # default is RetricSu/godwoken-kicker
       #     GODWOKEN_KICKER_REF=helloworld # default is compatibility-changes
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout godwoken-tests
       uses: actions/checkout@v3
       with:
-        repository: ${{ env.GODWOKEN_TESTS_REPO || 'nervosnetwork/godwoken-tests' }}
+        repository: ${{ env.GODWOKEN_TESTS_REPO || 'godwokenrises/godwoken-tests' }}
         ref: ${{ env.GODWOKEN_TESTS_REF || 'develop' }}
         submodules: 'recursive'
 


### PR DESCRIPTION
Since godwoken-tests has moved from `nervosnetwork` to `godwokenrises`, we need to also change the organization name used in the repo workflows.

But the chat-bot workflow remains the same, please take a look at this:
https://github.com/godwokenrises/godwoken-tests/blob/develop/.github/workflows/integration-test-chat-bot-v1.yml#L48