### PR TITLE
chore(ci): only runs v0 checks on v0 branch

### DIFF
--- a/.github/workflows/reusable-integration-test-v0.yml
+++ b/.github/workflows/reusable-integration-test-v0.yml
@@ -42,7 +42,7 @@ on:
     - v0
   pull_request:
     branches:
-    - develop
+    - v0
 
 
 jobs:


### PR DESCRIPTION
Avoid running useless v0 checks on pull requests for v1.