### PR TITLE
chore: skip Multicall2 test

### DIFF
--- a/contracts/test/Multicall2.js
+++ b/contracts/test/Multicall2.js
@@ -4,7 +4,7 @@ const { isGwMainnetV1 } = require('../utils/network');
 
 const { BigNumber, constants } = ethers;
 
-describe("Multicall2", function () {
+describe.skip("Multicall2", function () {
   if (isGwMainnetV1()) {
     return;
   }


### PR DESCRIPTION
Skip the multicall2 test case for now until we fix the `revert` issue in polyjuice.