### PR TITLE
Update alphanet rpc url

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -36,7 +36,7 @@ module.exports = {
       chainId: 71401,
     },
     gw_alphanet_v1: { // for internal testing
-      url: `https://godwoken-alphanet-v1.ckbapp.dev`,
+      url: `https://gw-alphanet-v1.godwoken.cf`,
       accounts: [`0x${TEST_PK1}`, `0x${TEST_PK2}`,`${PRIVATE_KEY0}`, `${PRIVATE_KEY1}`],
       chainId: 202206,
       gasPrice: 1,

--- a/scripts/account-faucet/src/config.ts
+++ b/scripts/account-faucet/src/config.ts
@@ -27,7 +27,7 @@ export const networks : Record<Network, NetworkConfig> = {
     },
   },
   [Network.AlphanetV1]: {
-    rpc: 'https://godwoken-alphanet-v1.ckbapp.dev',
+    rpc: 'https://gw-alphanet-v1.godwoken.cf',
     lumos: {
       config: predefined.AGGRON4
     },

--- a/scripts/light-godwoken-cli/src/config.ts
+++ b/scripts/light-godwoken-cli/src/config.ts
@@ -28,7 +28,7 @@ export const networks : Record<Network, NetworkConfig> = {
     version: 'v1',
   },
   [Network.AlphanetV1]: {
-    rpc: 'https://godwoken-alphanet-v1.ckbapp.dev',
+    rpc: 'https://gw-alphanet-v1.godwoken.cf',
     network: 'alphanet',
     version: 'v1',
     lightGodwokenConfig: alphanetConfigV1,

--- a/scripts/light-godwoken-cli/src/configs/alphanet.ts
+++ b/scripts/light-godwoken-cli/src/configs/alphanet.ts
@@ -69,7 +69,7 @@ export const alphanetConfigV1: LightGodwokenConfig = {
       },
     },
 
-    GW_POLYJUICE_RPC_URL: "https://godwoken-alphanet-v1.ckbapp.dev",
+    GW_POLYJUICE_RPC_URL: "https://gw-alphanet-v1.godwoken.cf",
     SCANNER_URL: "", // might not need this
     SCANNER_API: "", // might not need this
     CHAIN_NAME: "Godwoken Alphanet v1",


### PR DESCRIPTION
We now have a new Alphanet_v1 RPC url `https://gw-alphanet-v1.godwoken.cf`, replacing for:
- contracts
- scripts/account-faucet
- script/light-godowken-cli