### PR TITLE
ci: bump actions/github-script to v6

### DIFF
--- a/.github/workflows/account-analysis.yml
+++ b/.github/workflows/account-analysis.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive' 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Get npm cache directory

--- a/.github/workflows/batch-transactions.yml
+++ b/.github/workflows/batch-transactions.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Get yarn cache directory path

--- a/.github/workflows/deposit_and_withdraw.yml
+++ b/.github/workflows/deposit_and_withdraw.yml
@@ -27,7 +27,7 @@ jobs:
         repository: Flouse/godwoken-examples
         ref: v1
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Get yarn cache directory path

--- a/.github/workflows/fee-test.yml
+++ b/.github/workflows/fee-test.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Get yarn cache directory path

--- a/.github/workflows/reusable-integration-test-v0.yml
+++ b/.github/workflows/reusable-integration-test-v0.yml
@@ -199,7 +199,7 @@ jobs:
         fi
         sudo chown -R `whoami` cache/build
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Get yarn cache directory path
@@ -243,7 +243,7 @@ jobs:
     
     - name: Get current layer2 block number
       id: deposit-block-num
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const { getTipBlockNumber } = require("./scripts/helper");
@@ -289,7 +289,7 @@ jobs:
     # Note:
     # The deposited asset can be withdrawn only after `finalize_blocks` layer2 blocks.
     - name: Wait until [finalize_blocks] layer2 blocks passed
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const { getTipBlockNumber, waitXl2BlocksPassed } = require("./scripts/helper");
@@ -313,7 +313,7 @@ jobs:
         fi
 
     - name: Wait 2 layer2 blocks passed
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const { waitXl2BlocksPassed } = require("./scripts/helper");
@@ -330,7 +330,7 @@ jobs:
     
     - name: Get current layer2 block number
       id: withdrawal-block-num
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const { getTipBlockNumber } = require("./scripts/helper");
@@ -338,7 +338,7 @@ jobs:
         result-encoding: string
 
     - name: Wait until [finalize_blocks] layer2 blocks passed
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const { waitXl2BlocksPassed } = require("./scripts/helper");

--- a/.github/workflows/reusable-integration-test-v1.yml
+++ b/.github/workflows/reusable-integration-test-v1.yml
@@ -169,7 +169,7 @@ jobs:
         ./kicker deposit 0x4fef21f1d42e0d23d72100aefe84d555781c31bb 10000
       
     - name: Wait 1 layer2 blocks passed
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const { waitXl2BlocksPassed } = require("./scripts/helper");
@@ -188,7 +188,7 @@ jobs:
         ./kicker deposit-v0 10000 # Use ckb-miner key
     
     - name: Wait 1 layer2 blocks passed
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const { waitXl2BlocksPassed } = require("./scripts/helper");
@@ -214,7 +214,7 @@ jobs:
         echo "withdraw from v0 to v1 fail"
         exit 1
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - name: Get yarn cache directory path
@@ -238,7 +238,7 @@ jobs:
         yarn install && yarn build-all
 
     - name: Wait 1 layer2 blocks passed
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const { waitXl2BlocksPassed } = require("./scripts/helper");


### PR DESCRIPTION
It seems that actions/github-actions@v5 is deprecated and using it would cause CI failed(e.g. [job 5791521387](https://github.com/godwokenrises/godwoken-tests/actions/runs/3458758004/jobs/5791521387) ). So I bump it to [v6](https://github.com/actions/github-script#breaking-changes-in-v6).

