### PR TITLE
chore: replace testnet rpc url

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -31,7 +31,7 @@ module.exports = {
       accounts: [`0x${TEST_PK1}`, `0x${TEST_PK2}`,`${PRIVATE_KEY0}`, `${PRIVATE_KEY1}`],
     },
     gw_testnet_v1: {
-      url: `https://godwoken-testnet-v1.ckbapp.dev/instant-finality-hack`,
+      url: `https://v1.testnet.godwoken.io/rpc/instant-finality-hack`,
       accounts: [`0x${TEST_PK1}`, `0x${TEST_PK2}`, `0x${TEST_PK3}`,`${PRIVATE_KEY0}`, `${PRIVATE_KEY1}`],
       chainId: 71401,
     },

--- a/scripts/account-faucet/src/config.ts
+++ b/scripts/account-faucet/src/config.ts
@@ -14,13 +14,13 @@ export interface NetworkConfig {
 
 export const networks : Record<Network, NetworkConfig> = {
   [Network.TestnetV1]: {
-    rpc: 'https://godwoken-testnet-v1.ckbapp.dev',
+    rpc: 'https://v1.testnet.godwoken.io/rpc/instant-finality-hack',
     lumos: {
       config: predefined.AGGRON4
     },
   },
   [Network.AlphanetV1]: {
-    rpc: 'https://gw-alphanet-v1.godwoken.cf',
+    rpc: 'https://gw-alphanet-v1.godwoken.cf/instant-finality-hack',
     lumos: {
       config: predefined.AGGRON4
     },

--- a/scripts/light-godwoken-cli/src/config.ts
+++ b/scripts/light-godwoken-cli/src/config.ts
@@ -31,13 +31,13 @@ export const networks : Record<Network, NetworkConfig> = {
     lightGodwokenConfig: predefinedConfigs.mainnet.v1,
   },
   [Network.TestnetV1]: {
-    rpc: 'https://godwoken-testnet-v1.ckbapp.dev',
+    rpc: 'https://v1.testnet.godwoken.io/rpc/instant-finality-hack',
     network: GodwokenNetwork.Testnet,
     version: GodwokenVersion.V1,
     lightGodwokenConfig: predefinedConfigs.testnet.v1,
   },
   [Network.AlphanetV1]: {
-    rpc: 'https://gw-alphanet-v1.godwoken.cf',
+    rpc: 'https://gw-alphanet-v1.godwoken.cf/instant-finality-hack',
     network: 'alphanet',
     version: GodwokenVersion.V1,
     lightGodwokenConfig: AlphanetConfigV1,

--- a/scripts/light-godwoken-cli/src/configs/alphanet.ts
+++ b/scripts/light-godwoken-cli/src/configs/alphanet.ts
@@ -69,7 +69,7 @@ export const AlphanetConfigV1: LightGodwokenConfig = {
       },
     },
 
-    GW_POLYJUICE_RPC_URL: "https://gw-alphanet-v1.godwoken.cf",
+    GW_POLYJUICE_RPC_URL: "https://gw-alphanet-v1.godwoken.cf/instant-finality-hack",
     SCANNER_URL: "", // might not need this
     SCANNER_API: "", // might not need this
     CHAIN_NAME: "Godwoken Alphanet v1",


### PR DESCRIPTION
Godwoken has a new Testnet RPC url, replacing:
- `godwoken-testnet-v1.ckbapp.dev` -> `v1.testnet.godwoken.io/rpc/instant-finality-hack`
- `gw-alphanet-v1.godwoken.cf` -> `gw-alphanet-v1.godwoken.cf/instant-finality-hack`