### PR TITLE
ci: replace set-output syntax and upgrade dep actions

### DIFF
--- a/.github/workflows/account-analysis.yml
+++ b/.github/workflows/account-analysis.yml
@@ -15,7 +15,7 @@ jobs:
         net: ['mainnet'] # 'testnet', 
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive' 
     - uses: actions/setup-node@v3
@@ -24,7 +24,7 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache-dir
       run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -37,7 +37,7 @@ jobs:
       run: npm install && npm run compile
 
     - name: Cache the account data 
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         key: account-data-${{ hashFiles('**/package-lock.json') }}
         path: |
@@ -48,7 +48,7 @@ jobs:
 
     - name: Archive the account data in dist/account_data_${{ matrix.net }}.json
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: account-data
         path: |

--- a/.github/workflows/account-analysis.yml
+++ b/.github/workflows/account-analysis.yml
@@ -23,7 +23,7 @@ jobs:
         node-version: '16'
     - name: Get npm cache directory
       id: npm-cache-dir
-      run: echo "::set-output name=dir::$(npm config get cache)"
+      run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v2
       id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
       with:

--- a/.github/workflows/account-faucet.yml
+++ b/.github/workflows/account-faucet.yml
@@ -34,7 +34,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |

--- a/.github/workflows/account-faucet.yml
+++ b/.github/workflows/account-faucet.yml
@@ -17,7 +17,7 @@ jobs:
           KEY2: '${{ secrets.GODWOKEN_TEST_PRIVATE_KEY2 }}'
           KEY3: '${{ secrets.GW_TESTNET_V1_TEST_PK }}'
         if: ${{ env.KEY1 != '' && env.KEY2 != '' && env.KEY3 != '' }}
-        run: echo "::set-output name=available::true"
+        run: echo "available=true" >> $GITHUB_OUTPUT
 
   account-faucet:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
         uses: actions/cache@v2
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/alphanet_openzeppelin_test.yml
+++ b/.github/workflows/alphanet_openzeppelin_test.yml
@@ -22,7 +22,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |
@@ -115,7 +115,7 @@ jobs:
           bash try.sh npm run test:pipeline5-19
       - name: Publish reports
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: jfoa-build-reports-${{ runner.os }}
           path: mochawesome-report/

--- a/.github/workflows/alphanet_openzeppelin_test.yml
+++ b/.github/workflows/alphanet_openzeppelin_test.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
         uses: actions/cache@v2
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/batch-deposit-withdraw.yml
+++ b/.github/workflows/batch-deposit-withdraw.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           KEY1: '${{ secrets.GODWOKEN_TEST_PRIVATE_KEY }}'
         if: ${{ env.KEY1 != '' }}
-        run: echo "::set-output name=available::true"
+        run: echo "available=true" >> $GITHUB_OUTPUT
 
   batch-deposit-and-withdraw:
     runs-on: ubuntu-latest

--- a/.github/workflows/batch-prepare.yml
+++ b/.github/workflows/batch-prepare.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           KEY1: '${{ secrets.GODWOKEN_TEST_PRIVATE_KEY }}'
         if: ${{ env.KEY1 != '' }}
-        run: echo "::set-output name=available::true"
+        run: echo "available=true" >> $GITHUB_OUTPUT
 
   batch-claim:
     needs: check-secrets

--- a/.github/workflows/batch-transactions.yml
+++ b/.github/workflows/batch-transactions.yml
@@ -20,7 +20,7 @@ jobs:
         net: ['testnet', 'alphanet']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - uses: actions/setup-node@v3
@@ -30,7 +30,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/batch-transactions.yml
+++ b/.github/workflows/batch-transactions.yml
@@ -28,7 +28,7 @@ jobs:
         node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
       uses: actions/cache@v2
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -29,7 +29,7 @@ jobs:
           KEY2: '${{ secrets.GODWOKEN_TEST_PRIVATE_KEY2 }}'
           KEY3: '${{ secrets.GW_TESTNET_V1_TEST_PK }}'
         if: ${{ env.KEY1 != '' && env.KEY2 != '' && env.KEY3 != '' }}
-        run: echo "::set-output name=available::true"
+        run: echo "available=true" >> $GITHUB_OUTPUT
 
   contract-tests:
     strategy:
@@ -47,7 +47,7 @@ jobs:
         node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
       uses: actions/cache@v2
       id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -49,7 +49,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: |

--- a/.github/workflows/deposit_and_withdraw.yml
+++ b/.github/workflows/deposit_and_withdraw.yml
@@ -32,7 +32,7 @@ jobs:
         node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
       uses: actions/cache@v2
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/deposit_and_withdraw.yml
+++ b/.github/workflows/deposit_and_withdraw.yml
@@ -34,7 +34,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/fee-test.yml
+++ b/.github/workflows/fee-test.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.repository == 'godwokenrises/godwoken-tests'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - uses: actions/setup-node@v3
@@ -31,7 +31,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/fee-test.yml
+++ b/.github/workflows/fee-test.yml
@@ -29,7 +29,7 @@ jobs:
         node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
       uses: actions/cache@v2
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/integration-test-chat-bot-v1.yml
+++ b/.github/workflows/integration-test-chat-bot-v1.yml
@@ -267,7 +267,7 @@ jobs:
 
       - name: Generate gw-bot token
         id: generate_gw_bot_token
-        uses: wow-actions/use-app-token@v1
+        uses: wow-actions/use-app-token@v2
         with:
           app_id: ${{ secrets.GW_BOT_APP_ID }}
           private_key: ${{ secrets.GW_BOT_PRIVATE_KEY }}
@@ -450,7 +450,7 @@ jobs:
       # Generate new token in case the tests run over an hour
       - name: Generate gw-bot token
         id: generate_gw_bot_token
-        uses: wow-actions/use-app-token@v1
+        uses: wow-actions/use-app-token@v2
         with:
           app_id: ${{ secrets.GW_BOT_APP_ID }}
           private_key: ${{ secrets.GW_BOT_PRIVATE_KEY }}

--- a/.github/workflows/integration-test-chat-bot-v1.yml
+++ b/.github/workflows/integration-test-chat-bot-v1.yml
@@ -433,7 +433,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
 
   run-integration-test:
     needs: component-info

--- a/.github/workflows/regression-contract-test.yml
+++ b/.github/workflows/regression-contract-test.yml
@@ -14,7 +14,7 @@ jobs:
           KEY1: '${{ secrets.GW_MAINNET_V1_PK1 }}'
           KEY2: '${{ secrets.GW_MAINNET_V1_PK2 }}'
         if: ${{ env.KEY1 != '' && env.KEY2 != '' }}
-        run: echo "::set-output name=available::true"
+        run: echo "available=true" >> $GITHUB_OUTPUT
 
   contract-tests:
     runs-on: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
         node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
       uses: actions/cache@v2
       id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/regression-contract-test.yml
+++ b/.github/workflows/regression-contract-test.yml
@@ -30,7 +30,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Node Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: |

--- a/.github/workflows/reusable-integration-test-v0.yml
+++ b/.github/workflows/reusable-integration-test-v0.yml
@@ -78,10 +78,10 @@ jobs:
     # set up buildx/BuildKit runner in the context,
     # make the Docker cache exportable and thus properly cacheable
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Rust Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/bin/
@@ -207,7 +207,7 @@ jobs:
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     # FIXME: cache failed
     # - name: Node Cache
-    #   uses: actions/cache@v2
+    #   uses: actions/cache@v3
     #   id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
     #   with:
     #     path: |
@@ -362,7 +362,7 @@ jobs:
         docker-compose logs > /tmp/kicker.log
     - name: Archive logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: kicker-logs
         path: |
@@ -370,7 +370,7 @@ jobs:
     
     - name: Archive the dumped transactions in kicker/workspace/debug-tx-dump
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: debug-tx-dump
         path: |

--- a/.github/workflows/reusable-integration-test-v0.yml
+++ b/.github/workflows/reusable-integration-test-v0.yml
@@ -204,7 +204,7 @@ jobs:
         node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     # FIXME: cache failed
     # - name: Node Cache
     #   uses: actions/cache@v2

--- a/.github/workflows/reusable-integration-test-v1.yml
+++ b/.github/workflows/reusable-integration-test-v1.yml
@@ -67,7 +67,7 @@ jobs:
         fi
 
     - name: Rust Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/bin/
@@ -108,7 +108,7 @@ jobs:
     # set up buildx/BuildKit runner in the context,
     # make the Docker cache exportable and thus properly cacheable
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     # Ensure clean state
     - name: Run Godwoken-Kicker clean
@@ -263,7 +263,7 @@ jobs:
         docker-compose logs > /tmp/kicker.log
     - name: Archive logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: kicker-logs
         path: |
@@ -271,7 +271,7 @@ jobs:
     
     - name: Archive the dumped transactions in kicker/workspace/debug-tx-dump
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: debug-tx-dump
         path: |

--- a/.github/workflows/reusable-integration-test-v1.yml
+++ b/.github/workflows/reusable-integration-test-v1.yml
@@ -224,7 +224,7 @@ jobs:
         node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     # FIXME: cache failed
     # - name: Node Cache
     #   uses: actions/cache@v2


### PR DESCRIPTION
### Description
GitHub is deprecating `set-output`, `save-state` and `node@12` on GitHub Actions.
To make sure everything works in the future, in this PR we should:
- Replace all `set-output` syntax to be in sync with latest standard
- Upgrade dependency actions to get rid of deprecated `node@12` and `save-state`

### Related materials
- [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)