### PR TITLE
fix(ci): `wow-actions/use-app-token` outputs changed

### DIFF
--- a/.github/workflows/integration-test-chat-bot-v1.yml
+++ b/.github/workflows/integration-test-chat-bot-v1.yml
@@ -276,7 +276,7 @@ jobs:
         id: post_workflow_run_comment
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.generate_gw_bot_token.outputs.token }}
+          github-token: ${{ steps.generate_gw_bot_token.outputs.BOT_TOKEN }}
           script: |
             const components_info = JSON.parse(`${{ steps.get_components.outputs.result }}`);
             const prebuilds = components_info.prebuilds;
@@ -458,7 +458,7 @@ jobs:
       - name: Update comment about integration test result
         uses: actions/github-script@v6
         with:
-          github-token: ${{ steps.generate_gw_bot_token.outputs.token }}
+          github-token: ${{ steps.generate_gw_bot_token.outputs.BOT_TOKEN }}
           script: |
             const dispatch = JSON.parse(`${{ github.event.inputs.dispatch }}`);
 


### PR DESCRIPTION
### Descrption
In previous PR #208 I've updated the version of the dep action `wow-actions/use-app-token`.
But I didn't notice the dep action has changed its outputs, which causes errors in the action: [Integration Test Chat bot #508](https://github.com/godwokenrises/godwoken-tests/actions/runs/3588975687/jobs/6040926217#step:4:83).

### Related material
- [Changes in wow-actions/use-app-token/README.md](https://github.com/wow-actions/use-app-token/commit/6e97d644e9c447640eb6bd74c9f5780d7c03d658#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R60)