### PR TITLE
feat: remove instant-finality-hack from rpc urls of lgc & account-faucet

### DIFF
--- a/scripts/account-faucet/src/config.ts
+++ b/scripts/account-faucet/src/config.ts
@@ -14,13 +14,13 @@ export interface NetworkConfig {
 
 export const networks : Record<Network, NetworkConfig> = {
   [Network.TestnetV1]: {
-    rpc: 'https://v1.testnet.godwoken.io/rpc/instant-finality-hack',
+    rpc: 'https://v1.testnet.godwoken.io/rpc',
     lumos: {
       config: predefined.AGGRON4
     },
   },
   [Network.AlphanetV1]: {
-    rpc: 'https://gw-alphanet-v1.godwoken.cf/instant-finality-hack',
+    rpc: 'https://gw-alphanet-v1.godwoken.cf',
     lumos: {
       config: predefined.AGGRON4
     },

--- a/scripts/light-godwoken-cli/src/config.ts
+++ b/scripts/light-godwoken-cli/src/config.ts
@@ -31,13 +31,13 @@ export const networks : Record<Network, NetworkConfig> = {
     lightGodwokenConfig: predefinedConfigs.mainnet.v1,
   },
   [Network.TestnetV1]: {
-    rpc: 'https://v1.testnet.godwoken.io/rpc/instant-finality-hack',
+    rpc: 'https://v1.testnet.godwoken.io/rpc',
     network: GodwokenNetwork.Testnet,
     version: GodwokenVersion.V1,
     lightGodwokenConfig: predefinedConfigs.testnet.v1,
   },
   [Network.AlphanetV1]: {
-    rpc: 'https://gw-alphanet-v1.godwoken.cf/instant-finality-hack',
+    rpc: 'https://gw-alphanet-v1.godwoken.cf',
     network: 'alphanet',
     version: GodwokenVersion.V1,
     lightGodwokenConfig: AlphanetConfigV1,

--- a/scripts/light-godwoken-cli/src/configs/alphanet.ts
+++ b/scripts/light-godwoken-cli/src/configs/alphanet.ts
@@ -69,7 +69,7 @@ export const AlphanetConfigV1: LightGodwokenConfig = {
       },
     },
 
-    GW_POLYJUICE_RPC_URL: "https://gw-alphanet-v1.godwoken.cf/instant-finality-hack",
+    GW_POLYJUICE_RPC_URL: "https://gw-alphanet-v1.godwoken.cf",
     SCANNER_URL: "", // might not need this
     SCANNER_API: "", // might not need this
     CHAIN_NAME: "Godwoken Alphanet v1",


### PR DESCRIPTION
Removing the `instant-finality-hack` from account-faucet and light-godwoken-cli, as this feature will only affects layer-2 transactions, not these two CLIs.

Related: https://github.com/godwokenrises/light-godwoken/pull/242