### PR TITLE
feat: enable mainnet_v1 in get-l2-address command of account-faucet

### DIFF
--- a/scripts/account-faucet/README.md
+++ b/scripts/account-faucet/README.md
@@ -34,7 +34,7 @@ You can use `-n` or `--network` option to claim faucet on different network:
 ```bash
 $ account-faucet claim-l2 --private-key <PRIVATE_KEY> --network <NETWORK>
 ```
-Right now the tool supports these networks:
+These networks are currently supported by most of the tool's commands:
 - testnet_v1
 - alphanet_v1
 
@@ -79,3 +79,8 @@ You can use `-n` or `--network` option to calculate the `L2 Deposit Address` on 
 ```bash
 $ account-faucet get-l2-address --eth-address <ETH_ADDRESS> --network <NETWORK>
 ```
+
+This command supports more networks than the other commands:
+- testnet_v1
+- alphanet_v1
+- mainnet_v1

--- a/scripts/account-faucet/src/commands/batch-claim-l1.ts
+++ b/scripts/account-faucet/src/commands/batch-claim-l1.ts
@@ -1,6 +1,6 @@
 import { HexString } from '@ckb-lumos/base';
 import { Command, Option } from 'commander';
-import { Network } from '../config';
+import { Network, testnetNetworks } from '../config';
 import { privateKeyToDerivedAccounts } from '../utils/derived';
 import { claimForL1 } from './claim-l1';
 import { addHexPrefix } from '../utils/address';
@@ -13,7 +13,7 @@ export default function setupBatchClaimForL1(program: Command) {
     .option('-c, --derived-count <INT>', 'amount of derived accounts to use', '30')
     .addOption(
       new Option('-n, --network <NETWORK>', 'network to use')
-        .choices(Object.values(Network))
+        .choices(testnetNetworks)
         .default(Network.TestnetV1)
     )
     .action(batchClaimForL1)

--- a/scripts/account-faucet/src/commands/batch-claim-l2.ts
+++ b/scripts/account-faucet/src/commands/batch-claim-l2.ts
@@ -1,6 +1,6 @@
 import { Address, HexString } from '@ckb-lumos/base';
 import { Command, Option } from 'commander';
-import { Network } from '../config';
+import { Network, testnetNetworks } from '../config';
 import { privateKeyToDerivedAccounts } from '../utils/derived';
 import { claimForL2 } from './claim-l2';
 import { addHexPrefix } from '../utils/address';
@@ -14,7 +14,7 @@ export default function setupBatchClaimForL2(program: Command) {
     .option('-c --ckb-address <ADDRESS>', 'ckb deposit-from address')
     .addOption(
       new Option('-n, --network <NETWORK>', 'network to use')
-        .choices(Object.values(Network))
+        .choices(testnetNetworks)
         .default(Network.TestnetV1)
     )
     .action(batchClaimForL2)

--- a/scripts/account-faucet/src/commands/claim-l1.ts
+++ b/scripts/account-faucet/src/commands/claim-l1.ts
@@ -1,6 +1,6 @@
 import { Address, HexString } from '@ckb-lumos/base';
 import { Command, Option } from 'commander';
-import { Network, networks } from '../config';
+import { Network, networks, testnetNetworks } from '../config';
 import { privateKeyToOmniCkbAddress, addHexPrefix } from '../utils/address';
 import { claimFaucetForCkbAddress } from '../utils/faucet';
 
@@ -12,7 +12,7 @@ export default function setupClaimForL1(program: Command) {
     .option('-c --ckb-address <ADDRESS>', 'ckb omni-lock address')
     .addOption(
       new Option('-n, --network <NETWORK>', 'network to use')
-        .choices(Object.values(Network))
+        .choices(testnetNetworks)
         .default(Network.TestnetV1)
     )
     .action(claimForL1)

--- a/scripts/account-faucet/src/commands/claim-l2.ts
+++ b/scripts/account-faucet/src/commands/claim-l2.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from 'commander';
-import { Network, networks } from '../config';
+import { Network, networks, testnetNetworks } from '../config';
 import { Address, HexString } from '@ckb-lumos/base';
 import { GodwokenWeb3 } from '../godwoken/web3';
 import { claimFaucetForCkbAddress } from '../utils/faucet';
@@ -20,7 +20,7 @@ export default function setupClaimForL2(program: Command) {
     .option('-c --ckb-address <ADDRESS>', 'ckb deposit-from address', DEFAULT_CKB_DEPOSIT_ADDRESS)
     .addOption(
       new Option('-n, --network <NETWORK>', 'network to use')
-        .choices(Object.values(Network))
+        .choices(testnetNetworks)
         .default(Network.TestnetV1)
     )
     .action(claimForL2)

--- a/scripts/account-faucet/src/commands/get-batch-accounts.ts
+++ b/scripts/account-faucet/src/commands/get-batch-accounts.ts
@@ -1,6 +1,6 @@
 import { HexString } from '@ckb-lumos/base';
 import { Command, Option } from 'commander';
-import { Network, networks } from '../config';
+import { Network, networks, testnetNetworks } from '../config';
 import { GodwokenWeb3 } from '../godwoken/web3';
 import { privateKeyToDerivedAccounts } from '../utils/derived';
 import { privateKeyToLayer2DepositAddress, privateKeyToOmniCkbAddress, addHexPrefix } from '../utils/address';
@@ -13,7 +13,7 @@ export default function setupBatchAccountsForL1(program: Command) {
     .option('-c, --derived-count <INT>', 'amount of derived accounts to use', '30')
     .addOption(
       new Option('-n, --network <NETWORK>', 'network to use')
-        .choices(Object.values(Network))
+        .choices(testnetNetworks)
         .default(Network.AlphanetV1)
     )
     .action(batchAccountsForL2)

--- a/scripts/account-faucet/src/config.ts
+++ b/scripts/account-faucet/src/config.ts
@@ -4,11 +4,21 @@ type ValueOf<T> = T[keyof T];
 export enum Network {
   TestnetV1 = 'testnet_v1',
   AlphanetV1 = 'alphanet_v1',
+  MainnetV1 = 'mainnet_v1',
 }
+
+export const testnetNetworks = [Network.TestnetV1, Network.AlphanetV1];
+export const allNetworks = Object.values(Network);
+
 export interface NetworkConfig {
   rpc: string;
   lumos: {
     config: ValueOf<typeof predefined>,
+  };
+  scripts: {
+    OMNI_LOCK: {
+      codeHash: string,
+    },
   };
 }
 
@@ -18,11 +28,32 @@ export const networks : Record<Network, NetworkConfig> = {
     lumos: {
       config: predefined.AGGRON4
     },
+    scripts: {
+      OMNI_LOCK: {
+        codeHash: '0x79f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e',
+      },
+    },
   },
   [Network.AlphanetV1]: {
     rpc: 'https://gw-alphanet-v1.godwoken.cf',
     lumos: {
       config: predefined.AGGRON4
+    },
+    scripts: {
+      OMNI_LOCK: {
+        codeHash: '0x79f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e',
+      },
+    },
+  },
+  [Network.MainnetV1]: {
+    rpc: 'https://v1.mainnet.godwoken.io/rpc',
+    lumos: {
+      config: predefined.LINA
+    },
+    scripts: {
+      OMNI_LOCK: {
+        codeHash: '0x9f3aeaf2fc439549cbc870c653374943af96a0658bd6b51be8d8983183e6f52f',
+      },
     },
   },
 };

--- a/scripts/account-faucet/src/godwoken/deposit.ts
+++ b/scripts/account-faucet/src/godwoken/deposit.ts
@@ -45,7 +45,7 @@ export function generateDepositLock(
   const depositLockArgs: DepositLockArgs = {
     owner_lock_hash: ownerLockHash,
     layer2_lock: layer2Lock,
-    cancel_timeout: "0xc000000000093a81",
+    cancel_timeout: "0xc000000000093a80",
     registry_id: '0x' + ETH_REGISTRY_ID,
   };
 

--- a/scripts/account-faucet/src/utils/address.ts
+++ b/scripts/account-faucet/src/utils/address.ts
@@ -57,23 +57,27 @@ export function privateKeyToCkbAddress(privateKey: HexString, config: NetworkCon
 
 export function privateKeyToOmniCkbAddress(privateKey: HexString, config: NetworkConfig): Address {
   const l2Address = privateKeyToEthAddress(privateKey);
+  return ethAddressToOmniCkbAddress(l2Address, config);
+}
+
+export function privateKeyToEthAddress(privateKey: HexString): HexString {
+  privateKey = addHexPrefix(privateKey);
+  return ethersUtils.computeAddress(privateKey);
+}
+
+export function ethAddressToOmniCkbAddress(ethAddress: HexString, config: NetworkConfig): Address {
   const omniLock: Script = {
-    code_hash: '0x79f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e', // TODO: replace the hard-code
+    code_hash: config.scripts.OMNI_LOCK.codeHash,
     hash_type: 'type',
     // omni flag       pubkey hash   omni lock flags
     // chain identity   eth addr      function flag()
     // 00: Nervos       👇            00: owner
     // 01: Ethereum     👇            01: administrator
     //      👇          👇            👇
-    args: `0x01${l2Address.substring(2)}00`,
+    args: `0x01${ethAddress.substring(2)}00`,
   };
 
   return encodeToAddress(omniLock, config.lumos);
-}
-
-export function privateKeyToEthAddress(privateKey: HexString): HexString {
-  privateKey = addHexPrefix(privateKey);
-  return ethersUtils.computeAddress(privateKey);
 }
 
 export function addHexPrefix(target: string): HexString {


### PR DESCRIPTION
Currently the account-faucet cli only supports `testnet_v1` and `alphanet_v1` networks, but the `get-l2-address` command might need to suuport more of it, so in this PR I'm adding `mainnet_v1` network to the tool.

Note that only the `get-l2-address` command can set the `network` to `mainnet_v1`, because other commands are designed to only works on testnet type of networks.