### PR TITLE
feat(lgc): collect legacy withdrawals' statistics

### DIFF
--- a/scripts/light-godwoken-cli/package-lock.json
+++ b/scripts/light-godwoken-cli/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.1.0",
       "dependencies": {
         "@ckb-lumos/base": "^0.18.0",
+        "@ckb-lumos/codec": "^0.18.0",
+        "@ckb-lumos/lumos": "^0.18.0",
         "@ckitjs/ckit": "^0.2.0",
         "axios": "^0.27.2",
         "ckb-js-toolkit": "^0.10.2",
@@ -22,7 +24,6 @@
       },
       "devDependencies": {
         "@ckb-lumos/config-manager": "^0.18.0",
-        "@ckb-lumos/lumos": "^0.18.0",
         "@ethersproject/abstract-signer": "^5.6.2",
         "esbuild": "^0.15.3",
         "keccak256": "^1.0.6",
@@ -72,7 +73,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/ckb-indexer/-/ckb-indexer-0.18.0.tgz",
       "integrity": "sha512-/p41EAgrh3QUQoc8aYPlKiOYdo3F99B9ed3mjzmMGEzLBJ4x+dGSKXSphsinrri/LHXT/51tSLHvAAG/X0/F/g==",
-      "dev": true,
       "dependencies": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -85,11 +85,21 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@ckb-lumos/codec": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/codec/-/codec-0.18.0.tgz",
+      "integrity": "sha512-W+KnK0HyFLuTx0d6cVD9cpjrwuZmQOSFF6SDqhuUQozh6Bsp+N15A93RDSl+hZPIzNWPMvGtNrJXu0BqTpdXSQ==",
+      "dependencies": {
+        "@ckb-lumos/bi": "0.18.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@ckb-lumos/common-scripts": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/common-scripts/-/common-scripts-0.18.0.tgz",
       "integrity": "sha512-J3ZxWTC1ZNKBn+aEm8uxjcgLujapyqudIbYnR/xhruMD0SyIsf50PPipOEMN8jCnzTMU4BmSIJOxJVidb7y/jQ==",
-      "dev": true,
       "dependencies": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -107,7 +117,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.18.0.tgz",
       "integrity": "sha512-xDmErZB1C5W5VRZmxMWSxpjVt2wjboyXSgpUp50nYo6TciUnYJaXEO8R8KL6U8UYyb1aOrga35vQkZCWMiWqOw==",
-      "dev": true,
       "dependencies": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -122,7 +131,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/hd/-/hd-0.18.0.tgz",
       "integrity": "sha512-K7u8Uw9B5SlxIaIgzhZDghxglcD2DpwkPgSrK3yFSnrrkoDgH5FovvfKQ8l7VtF1cq9NAb8g/MAaJRfTeuv7ww==",
-      "dev": true,
       "dependencies": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -139,7 +147,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/helpers/-/helpers-0.18.0.tgz",
       "integrity": "sha512-3xpmcBcLDLCSWx30LPG74cNnN0qSCb76dK9+r7TEMbsodpYJlklAsK0DzYNEa77v+jKuH4ribbwMEConcK+h7A==",
-      "dev": true,
       "dependencies": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -155,14 +162,12 @@
     "node_modules/@ckb-lumos/helpers/node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "dev": true
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@ckb-lumos/lumos": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/lumos/-/lumos-0.18.0.tgz",
       "integrity": "sha512-++kV50XvSLPw0OllncxuXw9eqLvav9VGRizMQFE5BWfgkU4s0e22fEy+YqqDcJQa0uEck7Lm9dsCOO8WD69WHw==",
-      "dev": true,
       "dependencies": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -182,7 +187,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/rpc/-/rpc-0.18.0.tgz",
       "integrity": "sha512-HwmLGT6ZUQ9LEorbMTLL6y9pz30Ti2yxHKlvT0w8kN7qlEDc4bzGN3UYtbeMoGR6VLPklJ/2/d/OnajAiLSrKw==",
-      "dev": true,
       "dependencies": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -3356,7 +3360,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -6646,7 +6649,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/ckb-indexer/-/ckb-indexer-0.18.0.tgz",
       "integrity": "sha512-/p41EAgrh3QUQoc8aYPlKiOYdo3F99B9ed3mjzmMGEzLBJ4x+dGSKXSphsinrri/LHXT/51tSLHvAAG/X0/F/g==",
-      "dev": true,
       "requires": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -6656,11 +6658,18 @@
         "events": "^3.3.0"
       }
     },
+    "@ckb-lumos/codec": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/codec/-/codec-0.18.0.tgz",
+      "integrity": "sha512-W+KnK0HyFLuTx0d6cVD9cpjrwuZmQOSFF6SDqhuUQozh6Bsp+N15A93RDSl+hZPIzNWPMvGtNrJXu0BqTpdXSQ==",
+      "requires": {
+        "@ckb-lumos/bi": "0.18.0"
+      }
+    },
     "@ckb-lumos/common-scripts": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/common-scripts/-/common-scripts-0.18.0.tgz",
       "integrity": "sha512-J3ZxWTC1ZNKBn+aEm8uxjcgLujapyqudIbYnR/xhruMD0SyIsf50PPipOEMN8jCnzTMU4BmSIJOxJVidb7y/jQ==",
-      "dev": true,
       "requires": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -6675,7 +6684,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.18.0.tgz",
       "integrity": "sha512-xDmErZB1C5W5VRZmxMWSxpjVt2wjboyXSgpUp50nYo6TciUnYJaXEO8R8KL6U8UYyb1aOrga35vQkZCWMiWqOw==",
-      "dev": true,
       "requires": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -6687,7 +6695,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/hd/-/hd-0.18.0.tgz",
       "integrity": "sha512-K7u8Uw9B5SlxIaIgzhZDghxglcD2DpwkPgSrK3yFSnrrkoDgH5FovvfKQ8l7VtF1cq9NAb8g/MAaJRfTeuv7ww==",
-      "dev": true,
       "requires": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -6701,7 +6708,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/helpers/-/helpers-0.18.0.tgz",
       "integrity": "sha512-3xpmcBcLDLCSWx30LPG74cNnN0qSCb76dK9+r7TEMbsodpYJlklAsK0DzYNEa77v+jKuH4ribbwMEConcK+h7A==",
-      "dev": true,
       "requires": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -6714,8 +6720,7 @@
         "bech32": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-          "dev": true
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
         }
       }
     },
@@ -6723,7 +6728,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/lumos/-/lumos-0.18.0.tgz",
       "integrity": "sha512-++kV50XvSLPw0OllncxuXw9eqLvav9VGRizMQFE5BWfgkU4s0e22fEy+YqqDcJQa0uEck7Lm9dsCOO8WD69WHw==",
-      "dev": true,
       "requires": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -6740,7 +6744,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/rpc/-/rpc-0.18.0.tgz",
       "integrity": "sha512-HwmLGT6ZUQ9LEorbMTLL6y9pz30Ti2yxHKlvT0w8kN7qlEDc4bzGN3UYtbeMoGR6VLPklJ/2/d/OnajAiLSrKw==",
-      "dev": true,
       "requires": {
         "@ckb-lumos/base": "0.18.0",
         "@ckb-lumos/bi": "0.18.0",
@@ -9090,8 +9093,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",

--- a/scripts/light-godwoken-cli/package.json
+++ b/scripts/light-godwoken-cli/package.json
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@ckb-lumos/config-manager": "^0.18.0",
-    "@ckb-lumos/lumos": "^0.18.0",
     "@ethersproject/abstract-signer": "^5.6.2",
     "esbuild": "^0.15.3",
     "keccak256": "^1.0.6",
@@ -23,6 +22,8 @@
   },
   "dependencies": {
     "@ckb-lumos/base": "^0.18.0",
+    "@ckb-lumos/lumos": "^0.18.0",
+    "@ckb-lumos/codec": "^0.18.0",
     "@ckitjs/ckit": "^0.2.0",
     "axios": "^0.27.2",
     "ckb-js-toolkit": "^0.10.2",

--- a/scripts/light-godwoken-cli/src/commands/get-legacy-withdrawals-stats.ts
+++ b/scripts/light-godwoken-cli/src/commands/get-legacy-withdrawals-stats.ts
@@ -1,0 +1,100 @@
+import { bytes, number, blockchain, createObjectCodec, enhancePack } from '@ckb-lumos/codec';
+import { BI, Indexer } from '@ckb-lumos/lumos';
+import { utils } from "ethers";
+import { Command } from 'commander';
+import { Network, networks } from '../config';
+import { createLightGodwoken } from '../utils/client';
+
+const { Uint128, Uint64 } = number;
+const { Byte32 } = blockchain;
+
+export function setupGetLegacyWithdrawalsStats(program: Command) {
+  program.command('get-legacy-withdrawals-stats')
+    .description("Get legacy withdrawals' statistics, only supports mainnet_v0 network")
+    .action(async () => await getLegacyWithdrawalsStats())
+  ;
+}
+
+export async function getLegacyWithdrawalsStats() {
+  const network = networks[Network.MainnetV0];
+  const client = await createLightGodwoken({
+    privateKey: "".padStart(64, "e"),
+    rpc: network.rpc,
+    network: network.network,
+    version: network.version,
+    config: network.lightGodwokenConfig,
+  });
+
+  const layer1Config = network.lightGodwokenConfig!.layer1Config;
+  const layer2Config = network.lightGodwokenConfig!.layer2Config;
+  const indexer = new Indexer(layer1Config.CKB_INDEXER_URL, layer1Config.CKB_RPC_URL);
+  const lastFinalizedBlockNumber = await client.provider.getLastFinalizedBlockNumber();
+
+  const collector = indexer.collector({
+    lock: {
+      code_hash: layer2Config.SCRIPTS.withdrawal_lock.script_type_hash,
+      args: layer2Config.ROLLUP_CONFIG.rollup_type_hash,
+      hash_type: "type",
+    },
+  });
+
+  let total = 0;
+  let finalized = 0;
+  let sudtCells = 0;
+  let capacity = BI.from(0);
+  for await (const cell of collector.collect()) {
+    const argsHex = cell.cell_output.lock.args;
+    const args = WithdrawalV0LockArgsV0.unpack(bytes.bytify(argsHex));
+
+    total += 1;
+    capacity = capacity.add(cell.cell_output.capacity);
+    if (args.withdrawalBlockNumber.lte(lastFinalizedBlockNumber)) {
+      finalized += 1;
+    }
+    if (!!cell.cell_output.type) {
+      sudtCells += 1;
+    }
+  }
+
+  console.log('total legacy withdrawals:');
+  console.log('-- total:', total);
+  console.log('-- finalized:', finalized);
+  console.log('-- non-finalized:', total - finalized);
+  console.log('total capacity in withdrawals:');
+  console.log('--', capacity.toString(), 'shannons');
+  console.log('--', utils.formatUnits(capacity.toString(), 8), 'CKB');
+  console.log('legacy withdrawal cells in categories:');
+  console.log('-- pure ckb cells:', total - sudtCells);
+  console.log('-- sudt cells:', sudtCells);
+}
+
+const RawWithdrawalLockArgsV0 = createObjectCodec({
+  rollupHash: Byte32,
+  accountScriptHash: Byte32,
+  withdrawalBlockhash: Byte32,
+  withdrawalBlockNumber: Uint64,
+  // buyer can pay sell_amount token to unlock
+  sudtScriptHash: Byte32,
+  sellAmount: Uint128,
+  sellCapacity: Uint64,
+  // layer1 lock to withdraw after challenge period
+  ownerLockHash: Byte32,
+  // layer1 lock to receive the payment, must exists on the chain
+  paymentLockHash: Byte32,
+});
+export const WithdrawalV0LockArgsV0 = enhancePack(
+  RawWithdrawalLockArgsV0,
+  () => new Uint8Array(0),
+  (buf: Uint8Array) => ({
+    rollupHash: buf.slice(0, 32),
+    accountScriptHash: buf.slice(32, 64),
+    withdrawalBlockhash: buf.slice(64, 96),
+    withdrawalBlockNumber: buf.slice(96, 104), // Uint64 = 8 length
+    sudtScriptHash: buf.slice(104, 136),
+    sellAmount: buf.slice(136, 152),
+    sellCapacity: buf.slice(152, 160),
+    ownerLockHash: buf.slice(160, 192),
+    paymentLockHash: buf.slice(192, 224),
+  }),
+);
+

--- a/scripts/light-godwoken-cli/src/index.ts
+++ b/scripts/light-godwoken-cli/src/index.ts
@@ -9,6 +9,8 @@ import getBalance from './commands/get-balance';
 import getTokenBalance from './commands/get-token-balance';
 import findTypeScript from './commands/find-script-tx';
 import deploySudtErc20Proxy from './commands/deploy-sudt-erc20-proxy';
+// generating statistics
+import { setupGetLegacyWithdrawalsStats } from './commands/get-legacy-withdrawals-stats';
 // for testing only
 import testCatch from './commands/batch-prepare-sudt';
 import batchPrepareSudt from './commands/test-catch';
@@ -21,6 +23,8 @@ const commands = [
   getTokenBalance,
   findTypeScript,
   deploySudtErc20Proxy,
+
+  setupGetLegacyWithdrawalsStats,
 
   testCatch,
   batchPrepareSudt,


### PR DESCRIPTION
Adding a command in lgc (scripts/light-godwoken-cli) to collect the statistics of legacy withdrawals.
This command is for mainnet_v0 only, so no parameters are required.

The output looks like this:
```shell
last finalized block number: 569196
total legacy withdrawals:
-- total: 1864
-- finalized: 1853
-- non-finalized: 11
total capacity in withdrawals:
-- 2545443173115492 shannons
-- 25454431.73115492 CKB
legacy withdrawal cells in categories:
-- pure ckb cells: 1801
-- sudt cells: 63
```