### PR TITLE
feat(lgc): add command `batch-combine-sudt` and `l1-transfer`

### DIFF
--- a/scripts/light-godwoken-cli/package-lock.json
+++ b/scripts/light-godwoken-cli/package-lock.json
@@ -8,22 +8,21 @@
       "name": "light-godwoken-cli",
       "version": "1.1.0",
       "dependencies": {
-        "@ckb-lumos/base": "^0.18.0",
-        "@ckb-lumos/codec": "^0.18.0",
-        "@ckb-lumos/lumos": "^0.18.0",
+        "@ckb-lumos/base": "^0.17.0",
+        "@ckb-lumos/codec": "^0.17.0",
+        "@ckb-lumos/config-manager": "^0.17.0",
+        "@ckb-lumos/lumos": "^0.17.0",
         "@ckitjs/ckit": "^0.2.0",
         "axios": "^0.27.2",
         "ckb-js-toolkit": "^0.10.2",
         "commander": "^9.3.0",
         "dotenv": "^16.0.1",
-        "ethers": "^5.6.9",
-        "ts-node-dev": "^2.0.0"
+        "ethers": "^5.6.9"
       },
       "bin": {
         "lgc": "bin/cli"
       },
       "devDependencies": {
-        "@ckb-lumos/config-manager": "^0.18.0",
         "@ethersproject/abstract-signer": "^5.6.2",
         "esbuild": "^0.15.3",
         "keccak256": "^1.0.6",
@@ -40,186 +39,6 @@
       }
     },
     "node_modules/@ckb-lumos/base": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.18.0.tgz",
-      "integrity": "sha512-+CW+e7iQcAqSFDzU2UDaPoEpncuQfFx4PnzTsmC6Nr70IAi4BdwZVl+8H5usYHhSZMzkCMXJ4aK2nLquEPmcdA==",
-      "dependencies": {
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0",
-        "@types/lodash.isequal": "^4.5.5",
-        "blake2b": "^2.1.3",
-        "js-xxhash": "^1.0.4",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "jsbi": "^4.1.0"
-      }
-    },
-    "node_modules/@ckb-lumos/bi": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.18.0.tgz",
-      "integrity": "sha512-0gvj75dDM9i6BFbE40ja9Z9vqrnW9FiyVPxvSSa1lTdOoCenPusJXdZUwBBLnfq4kRVsPC5pWcohTDhieyCbuA==",
-      "dependencies": {
-        "jsbi": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/ckb-indexer": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/ckb-indexer/-/ckb-indexer-0.18.0.tgz",
-      "integrity": "sha512-/p41EAgrh3QUQoc8aYPlKiOYdo3F99B9ed3mjzmMGEzLBJ4x+dGSKXSphsinrri/LHXT/51tSLHvAAG/X0/F/g==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/rpc": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0",
-        "cross-fetch": "^3.1.5",
-        "events": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/codec": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/codec/-/codec-0.18.0.tgz",
-      "integrity": "sha512-W+KnK0HyFLuTx0d6cVD9cpjrwuZmQOSFF6SDqhuUQozh6Bsp+N15A93RDSl+hZPIzNWPMvGtNrJXu0BqTpdXSQ==",
-      "dependencies": {
-        "@ckb-lumos/bi": "0.18.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/common-scripts": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/common-scripts/-/common-scripts-0.18.0.tgz",
-      "integrity": "sha512-J3ZxWTC1ZNKBn+aEm8uxjcgLujapyqudIbYnR/xhruMD0SyIsf50PPipOEMN8jCnzTMU4BmSIJOxJVidb7y/jQ==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/config-manager": "0.18.0",
-        "@ckb-lumos/helpers": "0.18.0",
-        "@ckb-lumos/rpc": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0",
-        "immutable": "^4.0.0-rc.12"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/config-manager": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.18.0.tgz",
-      "integrity": "sha512-xDmErZB1C5W5VRZmxMWSxpjVt2wjboyXSgpUp50nYo6TciUnYJaXEO8R8KL6U8UYyb1aOrga35vQkZCWMiWqOw==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@types/deep-freeze-strict": "^1.1.0",
-        "deep-freeze-strict": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/hd": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/hd/-/hd-0.18.0.tgz",
-      "integrity": "sha512-K7u8Uw9B5SlxIaIgzhZDghxglcD2DpwkPgSrK3yFSnrrkoDgH5FovvfKQ8l7VtF1cq9NAb8g/MAaJRfTeuv7ww==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "bn.js": "^5.1.3",
-        "elliptic": "^6.5.4",
-        "sha3": "^2.1.3",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/helpers": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/helpers/-/helpers-0.18.0.tgz",
-      "integrity": "sha512-3xpmcBcLDLCSWx30LPG74cNnN0qSCb76dK9+r7TEMbsodpYJlklAsK0DzYNEa77v+jKuH4ribbwMEConcK+h7A==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/config-manager": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0",
-        "bech32": "^2.0.0",
-        "immutable": "^4.0.0-rc.12"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/helpers/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
-    "node_modules/@ckb-lumos/lumos": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/lumos/-/lumos-0.18.0.tgz",
-      "integrity": "sha512-++kV50XvSLPw0OllncxuXw9eqLvav9VGRizMQFE5BWfgkU4s0e22fEy+YqqDcJQa0uEck7Lm9dsCOO8WD69WHw==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/ckb-indexer": "0.18.0",
-        "@ckb-lumos/common-scripts": "0.18.0",
-        "@ckb-lumos/config-manager": "0.18.0",
-        "@ckb-lumos/hd": "0.18.0",
-        "@ckb-lumos/helpers": "0.18.0",
-        "@ckb-lumos/rpc": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/rpc": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/rpc/-/rpc-0.18.0.tgz",
-      "integrity": "sha512-HwmLGT6ZUQ9LEorbMTLL6y9pz30Ti2yxHKlvT0w8kN7qlEDc4bzGN3UYtbeMoGR6VLPklJ/2/d/OnajAiLSrKw==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckb-lumos/toolkit": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.18.0.tgz",
-      "integrity": "sha512-1m4H52bX2E08VlV9P8eAHOGr4Lbc/Soya53+iwJbsQSH3gXUyWcxDKz5T4iIPMqfYuOztRF01wFdGPD0WPyEJQ==",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "cross-fetch": "^3.1.4",
-        "jsbi": "^4.1.0"
-      }
-    },
-    "node_modules/@ckitjs/base": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ckitjs/base/-/base-0.2.0.tgz",
-      "integrity": "sha512-d9ITJbOphd113/3vcFJU19iIEA8zaPz8CqmsFxQcGC2hIGfFzFlYvPb3+XRIG+YTTZkRsHPtlb9ZEnl+owxrmg==",
-      "dependencies": {
-        "@ckb-lumos/base": "^0.17.0-rc9",
-        "@ckb-lumos/config-manager": "^0.17.0-rc9",
-        "@ckitjs/utils": "0.2.0",
-        "eventemitter3": "^4.0.7"
-      }
-    },
-    "node_modules/@ckitjs/base/node_modules/@ckb-lumos/base": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
       "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
@@ -238,7 +57,7 @@
         "jsbi": "^4.1.0"
       }
     },
-    "node_modules/@ckitjs/base/node_modules/@ckb-lumos/bi": {
+    "node_modules/@ckb-lumos/bi": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
       "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
@@ -249,7 +68,51 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@ckitjs/base/node_modules/@ckb-lumos/config-manager": {
+    "node_modules/@ckb-lumos/ckb-indexer": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/ckb-indexer/-/ckb-indexer-0.17.0.tgz",
+      "integrity": "sha512-Cf8m7wovVUZktKwgCdgVx2KE9tTbYoYYvzy9TZhosgrkQ9YiYc0WoeIDnTv2JiUWB1AmVVKN4lgqIHnZ2RSGmQ==",
+      "dependencies": {
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/rpc": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0",
+        "cross-fetch": "^3.1.5",
+        "events": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@ckb-lumos/codec": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/codec/-/codec-0.17.0.tgz",
+      "integrity": "sha512-9/gpI2rFqvUI3f7YXYhYuRRP52/rdeDUilTeafjUPuFZ7UwLg8Lh/f3oOl6h3ck3hyPu0nDsz3Qf/36U4w17Ew==",
+      "dependencies": {
+        "@ckb-lumos/bi": "0.17.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@ckb-lumos/common-scripts": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/common-scripts/-/common-scripts-0.17.0.tgz",
+      "integrity": "sha512-usmckI5tIvRQJkrdzZOr5mAlTYsRg+ogyexw8/xmkrkq0a+Dj2v7tGILC7y75eiVj9B4et8/1JO07+Ru0xCkOw==",
+      "dependencies": {
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/config-manager": "0.17.0",
+        "@ckb-lumos/helpers": "0.17.0",
+        "@ckb-lumos/rpc": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0",
+        "immutable": "^4.0.0-rc.12"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@ckb-lumos/config-manager": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.17.0.tgz",
       "integrity": "sha512-I8eCV8bAyE/v+uGcu0YOB43v4ZUwTY9dHpE67gW5VJzloXFdIUedpgMpeySA/rmicZ3yhzoh2WhE5CmqGkDU5Q==",
@@ -263,7 +126,76 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@ckitjs/base/node_modules/@ckb-lumos/toolkit": {
+    "node_modules/@ckb-lumos/hd": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/hd/-/hd-0.17.0.tgz",
+      "integrity": "sha512-epUGWfrAVv5a6Ilu8nC4NwW8Riza/qTBHbaYAX8D3r161H9JlO4i7XTysTpWDCuZKJ/Aa9JelsgcMinqbf5ZpA==",
+      "dependencies": {
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "bn.js": "^5.1.3",
+        "elliptic": "^6.5.4",
+        "sha3": "^2.1.3",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@ckb-lumos/helpers": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/helpers/-/helpers-0.17.0.tgz",
+      "integrity": "sha512-sfZsTSLrLJ1HGOwBCcYJrG4tq4LllOzbw42o6MObg1DNvzKAK4A/lu2zMi61sKMVdNB5I0zgqT1JtKurzw5jcw==",
+      "dependencies": {
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/config-manager": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0",
+        "bech32": "^2.0.0",
+        "immutable": "^4.0.0-rc.12"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@ckb-lumos/helpers/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/@ckb-lumos/lumos": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/lumos/-/lumos-0.17.0.tgz",
+      "integrity": "sha512-J6HFcZ7C+Mi9SoTTleseJhcaZvmiLD6tlCz5vKw0wbfbpMr3io6tmAKcJ/ZHV51x+QoaeuBUdpQOnxhz6AhxuA==",
+      "dependencies": {
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/ckb-indexer": "0.17.0",
+        "@ckb-lumos/common-scripts": "0.17.0",
+        "@ckb-lumos/config-manager": "0.17.0",
+        "@ckb-lumos/hd": "0.17.0",
+        "@ckb-lumos/helpers": "0.17.0",
+        "@ckb-lumos/rpc": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@ckb-lumos/rpc": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/rpc/-/rpc-0.17.0.tgz",
+      "integrity": "sha512-UuR4LDo8sFOebSMqeai9KuF/DHl731dLYRuXRMURNx8QXVnHo2PXGtzCJs+F0DrJg0WECcAEAkJKh2/0ZDTJWw==",
+      "dependencies": {
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@ckb-lumos/toolkit": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
       "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
@@ -273,6 +205,17 @@
       "peerDependencies": {
         "cross-fetch": "^3.1.4",
         "jsbi": "^4.1.0"
+      }
+    },
+    "node_modules/@ckitjs/base": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@ckitjs/base/-/base-0.2.0.tgz",
+      "integrity": "sha512-d9ITJbOphd113/3vcFJU19iIEA8zaPz8CqmsFxQcGC2hIGfFzFlYvPb3+XRIG+YTTZkRsHPtlb9ZEnl+owxrmg==",
+      "dependencies": {
+        "@ckb-lumos/base": "^0.17.0-rc9",
+        "@ckb-lumos/config-manager": "^0.17.0-rc9",
+        "@ckitjs/utils": "0.2.0",
+        "eventemitter3": "^4.0.7"
       }
     },
     "node_modules/@ckitjs/ckit": {
@@ -302,112 +245,6 @@
         "jsbi": "^4.1.0"
       }
     },
-    "node_modules/@ckitjs/ckit/node_modules/@ckb-lumos/base": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
-      "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
-      "dependencies": {
-        "@ckb-lumos/bi": "0.17.0",
-        "@ckb-lumos/toolkit": "0.17.0",
-        "@types/lodash.isequal": "^4.5.5",
-        "blake2b": "^2.1.3",
-        "js-xxhash": "^1.0.4",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "jsbi": "^4.1.0"
-      }
-    },
-    "node_modules/@ckitjs/ckit/node_modules/@ckb-lumos/bi": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
-      "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
-      "dependencies": {
-        "jsbi": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckitjs/ckit/node_modules/@ckb-lumos/config-manager": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.17.0.tgz",
-      "integrity": "sha512-I8eCV8bAyE/v+uGcu0YOB43v4ZUwTY9dHpE67gW5VJzloXFdIUedpgMpeySA/rmicZ3yhzoh2WhE5CmqGkDU5Q==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.17.0",
-        "@ckb-lumos/bi": "0.17.0",
-        "@types/deep-freeze-strict": "^1.1.0",
-        "deep-freeze-strict": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckitjs/ckit/node_modules/@ckb-lumos/hd": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/hd/-/hd-0.17.0.tgz",
-      "integrity": "sha512-epUGWfrAVv5a6Ilu8nC4NwW8Riza/qTBHbaYAX8D3r161H9JlO4i7XTysTpWDCuZKJ/Aa9JelsgcMinqbf5ZpA==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.17.0",
-        "@ckb-lumos/bi": "0.17.0",
-        "bn.js": "^5.1.3",
-        "elliptic": "^6.5.4",
-        "sha3": "^2.1.3",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckitjs/ckit/node_modules/@ckb-lumos/helpers": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/helpers/-/helpers-0.17.0.tgz",
-      "integrity": "sha512-sfZsTSLrLJ1HGOwBCcYJrG4tq4LllOzbw42o6MObg1DNvzKAK4A/lu2zMi61sKMVdNB5I0zgqT1JtKurzw5jcw==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.17.0",
-        "@ckb-lumos/bi": "0.17.0",
-        "@ckb-lumos/config-manager": "0.17.0",
-        "@ckb-lumos/toolkit": "0.17.0",
-        "bech32": "^2.0.0",
-        "immutable": "^4.0.0-rc.12"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckitjs/ckit/node_modules/@ckb-lumos/rpc": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/rpc/-/rpc-0.17.0.tgz",
-      "integrity": "sha512-UuR4LDo8sFOebSMqeai9KuF/DHl731dLYRuXRMURNx8QXVnHo2PXGtzCJs+F0DrJg0WECcAEAkJKh2/0ZDTJWw==",
-      "dependencies": {
-        "@ckb-lumos/base": "0.17.0",
-        "@ckb-lumos/bi": "0.17.0",
-        "@ckb-lumos/toolkit": "0.17.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckitjs/ckit/node_modules/@ckb-lumos/toolkit": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
-      "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "cross-fetch": "^3.1.4",
-        "jsbi": "^4.1.0"
-      }
-    },
-    "node_modules/@ckitjs/ckit/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
     "node_modules/@ckitjs/easy-byte": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@ckitjs/easy-byte/-/easy-byte-0.2.0.tgz",
@@ -429,48 +266,6 @@
         "@open-rpc/client-js": "^1.7.0"
       }
     },
-    "node_modules/@ckitjs/mercury-client/node_modules/@ckb-lumos/base": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
-      "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
-      "dependencies": {
-        "@ckb-lumos/bi": "0.17.0",
-        "@ckb-lumos/toolkit": "0.17.0",
-        "@types/lodash.isequal": "^4.5.5",
-        "blake2b": "^2.1.3",
-        "js-xxhash": "^1.0.4",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "jsbi": "^4.1.0"
-      }
-    },
-    "node_modules/@ckitjs/mercury-client/node_modules/@ckb-lumos/bi": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
-      "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
-      "dependencies": {
-        "jsbi": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckitjs/mercury-client/node_modules/@ckb-lumos/toolkit": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
-      "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "cross-fetch": "^3.1.4",
-        "jsbi": "^4.1.0"
-      }
-    },
     "node_modules/@ckitjs/rc-lock": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@ckitjs/rc-lock/-/rc-lock-0.2.0.tgz",
@@ -482,48 +277,6 @@
         "@ckitjs/utils": "0.2.0",
         "ckb-js-toolkit": "^0.10.2",
         "rxjs": "^7.3.0"
-      }
-    },
-    "node_modules/@ckitjs/rc-lock/node_modules/@ckb-lumos/base": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
-      "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
-      "dependencies": {
-        "@ckb-lumos/bi": "0.17.0",
-        "@ckb-lumos/toolkit": "0.17.0",
-        "@types/lodash.isequal": "^4.5.5",
-        "blake2b": "^2.1.3",
-        "js-xxhash": "^1.0.4",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "jsbi": "^4.1.0"
-      }
-    },
-    "node_modules/@ckitjs/rc-lock/node_modules/@ckb-lumos/bi": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
-      "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
-      "dependencies": {
-        "jsbi": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@ckitjs/rc-lock/node_modules/@ckb-lumos/toolkit": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
-      "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "cross-fetch": "^3.1.4",
-        "jsbi": "^4.1.0"
       }
     },
     "node_modules/@ckitjs/utils": {
@@ -543,6 +296,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1258,6 +1012,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1265,12 +1020,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1442,22 +1199,26 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.1",
@@ -1551,16 +1312,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ=="
-    },
-    "node_modules/@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
-    },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
@@ -1582,6 +1333,7 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1593,6 +1345,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1617,22 +1370,11 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -1719,11 +1461,6 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.0.tgz",
       "integrity": "sha512-fsTxXxj1081Yq5MOQ06gZ5+e2QcSyP2U6NofdOWyq+lrNI4IjkZ+fLVmoQ6uUCiNg1NWePMMVq93vOTdbJmErw=="
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
     "node_modules/base-x": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
@@ -1775,14 +1512,6 @@
       "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/blake2b": {
@@ -1853,26 +1582,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/brorand": {
       "version": "1.1.0",
@@ -1991,11 +1700,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
     "node_modules/buffer-to-arraybuffer": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
@@ -2100,32 +1804,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-    },
-    "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
     },
     "node_modules/chownr": {
       "version": "1.1.4",
@@ -2240,11 +1918,6 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2357,7 +2030,8 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -2536,6 +2210,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -2566,14 +2241,6 @@
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/dynamic-dedupe": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
-      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
-      "dependencies": {
-        "xtend": "^4.0.0"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -3463,17 +3130,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
-    "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -3591,24 +3247,6 @@
         "minipass": "^2.6.0"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3695,36 +3333,6 @@
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/global": {
@@ -3972,15 +3580,6 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
       "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -4033,17 +3632,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -4070,17 +3658,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-date-object": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
@@ -4093,14 +3670,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-function": {
@@ -4122,17 +3691,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
@@ -4151,14 +3709,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -4415,7 +3965,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -4520,17 +4071,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/minimist": {
       "version": "1.2.6",
@@ -4729,14 +4269,6 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -4880,19 +4412,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -4917,17 +4436,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -5079,17 +4587,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -5172,22 +4669,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dependencies": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -5210,17 +4691,6 @@
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/ripemd160": {
@@ -5447,23 +4917,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/sshpk": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
@@ -5543,14 +4996,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-hex-prefix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
@@ -5561,25 +5006,6 @@
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/swarm-js": {
@@ -5735,17 +5161,6 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -5779,18 +5194,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5827,50 +5235,6 @@
         "@swc/wasm": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-node-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
-      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
-      "dependencies": {
-        "chokidar": "^3.5.1",
-        "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.6",
-        "mkdirp": "^1.0.4",
-        "resolve": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.2",
-        "ts-node": "^10.4.0",
-        "tsconfig": "^7.0.0"
-      },
-      "bin": {
-        "ts-node-dev": "lib/bin.js",
-        "tsnd": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "*",
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tsconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-      "dependencies": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
       }
     },
     "node_modules/tslib": {
@@ -5923,6 +5287,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6038,7 +5403,8 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/varint": {
       "version": "5.0.2",
@@ -6610,6 +5976,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6625,12 +5992,12 @@
       }
     },
     "@ckb-lumos/base": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.18.0.tgz",
-      "integrity": "sha512-+CW+e7iQcAqSFDzU2UDaPoEpncuQfFx4PnzTsmC6Nr70IAi4BdwZVl+8H5usYHhSZMzkCMXJ4aK2nLquEPmcdA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
+      "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
       "requires": {
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0",
         "@types/lodash.isequal": "^4.5.5",
         "blake2b": "^2.1.3",
         "js-xxhash": "^1.0.4",
@@ -6638,66 +6005,66 @@
       }
     },
     "@ckb-lumos/bi": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.18.0.tgz",
-      "integrity": "sha512-0gvj75dDM9i6BFbE40ja9Z9vqrnW9FiyVPxvSSa1lTdOoCenPusJXdZUwBBLnfq4kRVsPC5pWcohTDhieyCbuA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
+      "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
       "requires": {
         "jsbi": "^4.1.0"
       }
     },
     "@ckb-lumos/ckb-indexer": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/ckb-indexer/-/ckb-indexer-0.18.0.tgz",
-      "integrity": "sha512-/p41EAgrh3QUQoc8aYPlKiOYdo3F99B9ed3mjzmMGEzLBJ4x+dGSKXSphsinrri/LHXT/51tSLHvAAG/X0/F/g==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/ckb-indexer/-/ckb-indexer-0.17.0.tgz",
+      "integrity": "sha512-Cf8m7wovVUZktKwgCdgVx2KE9tTbYoYYvzy9TZhosgrkQ9YiYc0WoeIDnTv2JiUWB1AmVVKN4lgqIHnZ2RSGmQ==",
       "requires": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/rpc": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0",
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/rpc": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0"
       }
     },
     "@ckb-lumos/codec": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/codec/-/codec-0.18.0.tgz",
-      "integrity": "sha512-W+KnK0HyFLuTx0d6cVD9cpjrwuZmQOSFF6SDqhuUQozh6Bsp+N15A93RDSl+hZPIzNWPMvGtNrJXu0BqTpdXSQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/codec/-/codec-0.17.0.tgz",
+      "integrity": "sha512-9/gpI2rFqvUI3f7YXYhYuRRP52/rdeDUilTeafjUPuFZ7UwLg8Lh/f3oOl6h3ck3hyPu0nDsz3Qf/36U4w17Ew==",
       "requires": {
-        "@ckb-lumos/bi": "0.18.0"
+        "@ckb-lumos/bi": "0.17.0"
       }
     },
     "@ckb-lumos/common-scripts": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/common-scripts/-/common-scripts-0.18.0.tgz",
-      "integrity": "sha512-J3ZxWTC1ZNKBn+aEm8uxjcgLujapyqudIbYnR/xhruMD0SyIsf50PPipOEMN8jCnzTMU4BmSIJOxJVidb7y/jQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/common-scripts/-/common-scripts-0.17.0.tgz",
+      "integrity": "sha512-usmckI5tIvRQJkrdzZOr5mAlTYsRg+ogyexw8/xmkrkq0a+Dj2v7tGILC7y75eiVj9B4et8/1JO07+Ru0xCkOw==",
       "requires": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/config-manager": "0.18.0",
-        "@ckb-lumos/helpers": "0.18.0",
-        "@ckb-lumos/rpc": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0",
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/config-manager": "0.17.0",
+        "@ckb-lumos/helpers": "0.17.0",
+        "@ckb-lumos/rpc": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0",
         "immutable": "^4.0.0-rc.12"
       }
     },
     "@ckb-lumos/config-manager": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.18.0.tgz",
-      "integrity": "sha512-xDmErZB1C5W5VRZmxMWSxpjVt2wjboyXSgpUp50nYo6TciUnYJaXEO8R8KL6U8UYyb1aOrga35vQkZCWMiWqOw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.17.0.tgz",
+      "integrity": "sha512-I8eCV8bAyE/v+uGcu0YOB43v4ZUwTY9dHpE67gW5VJzloXFdIUedpgMpeySA/rmicZ3yhzoh2WhE5CmqGkDU5Q==",
       "requires": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
         "@types/deep-freeze-strict": "^1.1.0",
         "deep-freeze-strict": "^1.1.1"
       }
     },
     "@ckb-lumos/hd": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/hd/-/hd-0.18.0.tgz",
-      "integrity": "sha512-K7u8Uw9B5SlxIaIgzhZDghxglcD2DpwkPgSrK3yFSnrrkoDgH5FovvfKQ8l7VtF1cq9NAb8g/MAaJRfTeuv7ww==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/hd/-/hd-0.17.0.tgz",
+      "integrity": "sha512-epUGWfrAVv5a6Ilu8nC4NwW8Riza/qTBHbaYAX8D3r161H9JlO4i7XTysTpWDCuZKJ/Aa9JelsgcMinqbf5ZpA==",
       "requires": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
         "bn.js": "^5.1.3",
         "elliptic": "^6.5.4",
         "sha3": "^2.1.3",
@@ -6705,14 +6072,14 @@
       }
     },
     "@ckb-lumos/helpers": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/helpers/-/helpers-0.18.0.tgz",
-      "integrity": "sha512-3xpmcBcLDLCSWx30LPG74cNnN0qSCb76dK9+r7TEMbsodpYJlklAsK0DzYNEa77v+jKuH4ribbwMEConcK+h7A==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/helpers/-/helpers-0.17.0.tgz",
+      "integrity": "sha512-sfZsTSLrLJ1HGOwBCcYJrG4tq4LllOzbw42o6MObg1DNvzKAK4A/lu2zMi61sKMVdNB5I0zgqT1JtKurzw5jcw==",
       "requires": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/config-manager": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0",
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/config-manager": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0",
         "bech32": "^2.0.0",
         "immutable": "^4.0.0-rc.12"
       },
@@ -6725,35 +6092,35 @@
       }
     },
     "@ckb-lumos/lumos": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/lumos/-/lumos-0.18.0.tgz",
-      "integrity": "sha512-++kV50XvSLPw0OllncxuXw9eqLvav9VGRizMQFE5BWfgkU4s0e22fEy+YqqDcJQa0uEck7Lm9dsCOO8WD69WHw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/lumos/-/lumos-0.17.0.tgz",
+      "integrity": "sha512-J6HFcZ7C+Mi9SoTTleseJhcaZvmiLD6tlCz5vKw0wbfbpMr3io6tmAKcJ/ZHV51x+QoaeuBUdpQOnxhz6AhxuA==",
       "requires": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/ckb-indexer": "0.18.0",
-        "@ckb-lumos/common-scripts": "0.18.0",
-        "@ckb-lumos/config-manager": "0.18.0",
-        "@ckb-lumos/hd": "0.18.0",
-        "@ckb-lumos/helpers": "0.18.0",
-        "@ckb-lumos/rpc": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0"
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/ckb-indexer": "0.17.0",
+        "@ckb-lumos/common-scripts": "0.17.0",
+        "@ckb-lumos/config-manager": "0.17.0",
+        "@ckb-lumos/hd": "0.17.0",
+        "@ckb-lumos/helpers": "0.17.0",
+        "@ckb-lumos/rpc": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0"
       }
     },
     "@ckb-lumos/rpc": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/rpc/-/rpc-0.18.0.tgz",
-      "integrity": "sha512-HwmLGT6ZUQ9LEorbMTLL6y9pz30Ti2yxHKlvT0w8kN7qlEDc4bzGN3UYtbeMoGR6VLPklJ/2/d/OnajAiLSrKw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/rpc/-/rpc-0.17.0.tgz",
+      "integrity": "sha512-UuR4LDo8sFOebSMqeai9KuF/DHl731dLYRuXRMURNx8QXVnHo2PXGtzCJs+F0DrJg0WECcAEAkJKh2/0ZDTJWw==",
       "requires": {
-        "@ckb-lumos/base": "0.18.0",
-        "@ckb-lumos/bi": "0.18.0",
-        "@ckb-lumos/toolkit": "0.18.0"
+        "@ckb-lumos/base": "0.17.0",
+        "@ckb-lumos/bi": "0.17.0",
+        "@ckb-lumos/toolkit": "0.17.0"
       }
     },
     "@ckb-lumos/toolkit": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.18.0.tgz",
-      "integrity": "sha512-1m4H52bX2E08VlV9P8eAHOGr4Lbc/Soya53+iwJbsQSH3gXUyWcxDKz5T4iIPMqfYuOztRF01wFdGPD0WPyEJQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
+      "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
       "requires": {}
     },
     "@ckitjs/base": {
@@ -6765,46 +6132,6 @@
         "@ckb-lumos/config-manager": "^0.17.0-rc9",
         "@ckitjs/utils": "0.2.0",
         "eventemitter3": "^4.0.7"
-      },
-      "dependencies": {
-        "@ckb-lumos/base": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
-          "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
-          "requires": {
-            "@ckb-lumos/bi": "0.17.0",
-            "@ckb-lumos/toolkit": "0.17.0",
-            "@types/lodash.isequal": "^4.5.5",
-            "blake2b": "^2.1.3",
-            "js-xxhash": "^1.0.4",
-            "lodash.isequal": "^4.5.0"
-          }
-        },
-        "@ckb-lumos/bi": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
-          "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
-          "requires": {
-            "jsbi": "^4.1.0"
-          }
-        },
-        "@ckb-lumos/config-manager": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.17.0.tgz",
-          "integrity": "sha512-I8eCV8bAyE/v+uGcu0YOB43v4ZUwTY9dHpE67gW5VJzloXFdIUedpgMpeySA/rmicZ3yhzoh2WhE5CmqGkDU5Q==",
-          "requires": {
-            "@ckb-lumos/base": "0.17.0",
-            "@ckb-lumos/bi": "0.17.0",
-            "@types/deep-freeze-strict": "^1.1.0",
-            "deep-freeze-strict": "^1.1.1"
-          }
-        },
-        "@ckb-lumos/toolkit": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
-          "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
-          "requires": {}
-        }
       }
     },
     "@ckitjs/ckit": {
@@ -6829,87 +6156,6 @@
         "lodash": "^4.17.21",
         "rxjs": "^7.3.0",
         "secp256k1": "^4.0.0"
-      },
-      "dependencies": {
-        "@ckb-lumos/base": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
-          "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
-          "requires": {
-            "@ckb-lumos/bi": "0.17.0",
-            "@ckb-lumos/toolkit": "0.17.0",
-            "@types/lodash.isequal": "^4.5.5",
-            "blake2b": "^2.1.3",
-            "js-xxhash": "^1.0.4",
-            "lodash.isequal": "^4.5.0"
-          }
-        },
-        "@ckb-lumos/bi": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
-          "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
-          "requires": {
-            "jsbi": "^4.1.0"
-          }
-        },
-        "@ckb-lumos/config-manager": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/config-manager/-/config-manager-0.17.0.tgz",
-          "integrity": "sha512-I8eCV8bAyE/v+uGcu0YOB43v4ZUwTY9dHpE67gW5VJzloXFdIUedpgMpeySA/rmicZ3yhzoh2WhE5CmqGkDU5Q==",
-          "requires": {
-            "@ckb-lumos/base": "0.17.0",
-            "@ckb-lumos/bi": "0.17.0",
-            "@types/deep-freeze-strict": "^1.1.0",
-            "deep-freeze-strict": "^1.1.1"
-          }
-        },
-        "@ckb-lumos/hd": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/hd/-/hd-0.17.0.tgz",
-          "integrity": "sha512-epUGWfrAVv5a6Ilu8nC4NwW8Riza/qTBHbaYAX8D3r161H9JlO4i7XTysTpWDCuZKJ/Aa9JelsgcMinqbf5ZpA==",
-          "requires": {
-            "@ckb-lumos/base": "0.17.0",
-            "@ckb-lumos/bi": "0.17.0",
-            "bn.js": "^5.1.3",
-            "elliptic": "^6.5.4",
-            "sha3": "^2.1.3",
-            "uuid": "^8.3.0"
-          }
-        },
-        "@ckb-lumos/helpers": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/helpers/-/helpers-0.17.0.tgz",
-          "integrity": "sha512-sfZsTSLrLJ1HGOwBCcYJrG4tq4LllOzbw42o6MObg1DNvzKAK4A/lu2zMi61sKMVdNB5I0zgqT1JtKurzw5jcw==",
-          "requires": {
-            "@ckb-lumos/base": "0.17.0",
-            "@ckb-lumos/bi": "0.17.0",
-            "@ckb-lumos/config-manager": "0.17.0",
-            "@ckb-lumos/toolkit": "0.17.0",
-            "bech32": "^2.0.0",
-            "immutable": "^4.0.0-rc.12"
-          }
-        },
-        "@ckb-lumos/rpc": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/rpc/-/rpc-0.17.0.tgz",
-          "integrity": "sha512-UuR4LDo8sFOebSMqeai9KuF/DHl731dLYRuXRMURNx8QXVnHo2PXGtzCJs+F0DrJg0WECcAEAkJKh2/0ZDTJWw==",
-          "requires": {
-            "@ckb-lumos/base": "0.17.0",
-            "@ckb-lumos/bi": "0.17.0",
-            "@ckb-lumos/toolkit": "0.17.0"
-          }
-        },
-        "@ckb-lumos/toolkit": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
-          "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
-          "requires": {}
-        },
-        "bech32": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-        }
       }
     },
     "@ckitjs/easy-byte": {
@@ -6928,35 +6174,6 @@
         "@ckb-lumos/base": "^0.17.0-rc9",
         "@ckitjs/base": "0.2.0",
         "@open-rpc/client-js": "^1.7.0"
-      },
-      "dependencies": {
-        "@ckb-lumos/base": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
-          "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
-          "requires": {
-            "@ckb-lumos/bi": "0.17.0",
-            "@ckb-lumos/toolkit": "0.17.0",
-            "@types/lodash.isequal": "^4.5.5",
-            "blake2b": "^2.1.3",
-            "js-xxhash": "^1.0.4",
-            "lodash.isequal": "^4.5.0"
-          }
-        },
-        "@ckb-lumos/bi": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
-          "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
-          "requires": {
-            "jsbi": "^4.1.0"
-          }
-        },
-        "@ckb-lumos/toolkit": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
-          "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
-          "requires": {}
-        }
       }
     },
     "@ckitjs/rc-lock": {
@@ -6970,35 +6187,6 @@
         "@ckitjs/utils": "0.2.0",
         "ckb-js-toolkit": "^0.10.2",
         "rxjs": "^7.3.0"
-      },
-      "dependencies": {
-        "@ckb-lumos/base": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.17.0.tgz",
-          "integrity": "sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==",
-          "requires": {
-            "@ckb-lumos/bi": "0.17.0",
-            "@ckb-lumos/toolkit": "0.17.0",
-            "@types/lodash.isequal": "^4.5.5",
-            "blake2b": "^2.1.3",
-            "js-xxhash": "^1.0.4",
-            "lodash.isequal": "^4.5.0"
-          }
-        },
-        "@ckb-lumos/bi": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/bi/-/bi-0.17.0.tgz",
-          "integrity": "sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==",
-          "requires": {
-            "jsbi": "^4.1.0"
-          }
-        },
-        "@ckb-lumos/toolkit": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz",
-          "integrity": "sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==",
-          "requires": {}
-        }
       }
     },
     "@ckitjs/utils": {
@@ -7015,6 +6203,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
@@ -7417,17 +6606,20 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -7586,22 +6778,26 @@
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
     },
     "@types/bn.js": {
       "version": "5.1.1",
@@ -7695,16 +6891,6 @@
         "@types/node": "*"
       }
     },
-    "@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ=="
-    },
-    "@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
-    },
     "abortcontroller-polyfill": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
@@ -7722,12 +6908,14 @@
     "acorn": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "aes-js": {
       "version": "3.0.0",
@@ -7745,19 +6933,11 @@
         "uri-js": "^4.2.2"
       }
     },
-    "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
-    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -7834,11 +7014,6 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.0.tgz",
       "integrity": "sha512-fsTxXxj1081Yq5MOQ06gZ5+e2QcSyP2U6NofdOWyq+lrNI4IjkZ+fLVmoQ6uUCiNg1NWePMMVq93vOTdbJmErw=="
     },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
     "base-x": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
@@ -7874,11 +7049,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
       "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
-    },
-    "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "blake2b": {
       "version": "2.1.4",
@@ -7945,23 +7115,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
-      }
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "requires": {
-        "fill-range": "^7.0.1"
       }
     },
     "brorand": {
@@ -8069,11 +7222,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
     "buffer-to-arraybuffer": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
@@ -8152,21 +7300,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-    },
-    "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      }
     },
     "chownr": {
       "version": "1.1.4",
@@ -8255,11 +7388,6 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
       "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -8357,7 +7485,8 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -8486,7 +7615,8 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -8514,14 +7644,6 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
-    },
-    "dynamic-dedupe": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
-      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
-      "requires": {
-        "xtend": "^4.0.0"
-      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -9192,14 +8314,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
     "finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -9290,17 +8404,6 @@
         "minipass": "^2.6.0"
       }
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9360,27 +8463,6 @@
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "requires": {
-        "is-glob": "^4.0.1"
       }
     },
     "global": {
@@ -9561,15 +8643,6 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
       "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -9607,14 +8680,6 @@
         "has-bigints": "^1.0.1"
       }
     },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
     "is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -9629,14 +8694,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.6.tgz",
       "integrity": "sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q=="
     },
-    "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
     "is-date-object": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
@@ -9644,11 +8701,6 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
     },
     "is-function": {
       "version": "1.0.2",
@@ -9663,14 +8715,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
@@ -9680,11 +8724,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -9883,7 +8922,8 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -9966,14 +9006,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
-    },
-    "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
     },
     "minimist": {
       "version": "1.2.6",
@@ -10116,11 +9148,6 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
       "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
     },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-    },
     "normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -10229,16 +9256,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -10260,11 +9277,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "process": {
       "version": "0.11.10",
@@ -10385,14 +9397,6 @@
         "util-deprecate": "^1.0.1"
       }
     },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
@@ -10457,16 +9461,6 @@
         }
       }
     },
-    "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "requires": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
     "resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -10485,14 +9479,6 @@
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
         }
-      }
-    },
-    "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "requires": {
-        "glob": "^7.1.3"
       }
     },
     "ripemd160": {
@@ -10672,20 +9658,6 @@
         }
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "sshpk": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
@@ -10745,11 +9717,6 @@
         "es-abstract": "^1.19.5"
       }
     },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
-    },
     "strip-hex-prefix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
@@ -10757,16 +9724,6 @@
       "requires": {
         "is-hex-prefixed": "1.0.0"
       }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "swarm-js": {
       "version": "0.1.42",
@@ -10881,14 +9838,6 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
     "toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -10915,15 +9864,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
-    },
     "ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10938,34 +9883,6 @@
         "make-error": "^1.1.1",
         "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
-      }
-    },
-    "ts-node-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
-      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
-      "requires": {
-        "chokidar": "^3.5.1",
-        "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.6",
-        "mkdirp": "^1.0.4",
-        "resolve": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.2",
-        "ts-node": "^10.4.0",
-        "tsconfig": "^7.0.0"
-      }
-    },
-    "tsconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-      "requires": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
       }
     },
     "tslib": {
@@ -11011,7 +9928,8 @@
     "typescript": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "ultron": {
       "version": "1.1.1",
@@ -11101,7 +10019,8 @@
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "varint": {
       "version": "5.0.2",
@@ -11582,7 +10501,8 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/scripts/light-godwoken-cli/package.json
+++ b/scripts/light-godwoken-cli/package.json
@@ -13,7 +13,6 @@
     "lgc": "bin/cli"
   },
   "devDependencies": {
-    "@ckb-lumos/config-manager": "^0.18.0",
     "@ethersproject/abstract-signer": "^5.6.2",
     "esbuild": "^0.15.3",
     "keccak256": "^1.0.6",
@@ -21,15 +20,15 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@ckb-lumos/base": "^0.18.0",
-    "@ckb-lumos/lumos": "^0.18.0",
-    "@ckb-lumos/codec": "^0.18.0",
+    "@ckb-lumos/config-manager": "^0.17.0",
+    "@ckb-lumos/base": "^0.17.0",
+    "@ckb-lumos/lumos": "^0.17.0",
+    "@ckb-lumos/codec": "^0.17.0",
     "@ckitjs/ckit": "^0.2.0",
     "axios": "^0.27.2",
     "ckb-js-toolkit": "^0.10.2",
     "commander": "^9.3.0",
     "dotenv": "^16.0.1",
-    "ethers": "^5.6.9",
-    "ts-node-dev": "^2.0.0"
+    "ethers": "^5.6.9"
   }
 }

--- a/scripts/light-godwoken-cli/src/commands/batch-combine-sudt.ts
+++ b/scripts/light-godwoken-cli/src/commands/batch-combine-sudt.ts
@@ -1,0 +1,167 @@
+import { Command, Option } from 'commander';
+import { BI, helpers } from '@ckb-lumos/lumos';
+import { number, bytes } from '@ckb-lumos/codec';
+import { HexString, Cell, CellDep } from '@ckb-lumos/base';
+import { LightGodwokenConfig } from '../libraries/light-godwoken';
+import { Network } from '../config';
+import { getConfig } from '../utils/config';
+import { privateKeyToDerivedAccounts } from '../utils/account';
+import { createLightGodwokenByNetworkConfig } from '../utils/client';
+import { addHexPrefix, mustBeInteger } from '../utils/format';
+
+export default function setupBatchCombineSudt(program: Command) {
+  program
+    .command('batch-combine-sudt')
+    .description('Batch combine sudt cells into a single sudt cell')
+    .requiredOption('-p, --private-key <HEX_STRING>', 'account private key')
+    .option('--derived-count <INT>', 'amount of derived accounts to use', '30')
+    .option('--sudt-lock-args <HEX_STRING>', 'transfer sudt L1 lock_args', '0x5c7253696786b9eddd34e4f6b6e478ec5742bd36569ec60c1d0487480ba4f9e3')
+    .addOption(
+      new Option('-n, --network <NETWORK>', 'network to use')
+        .choices(Object.values(Network))
+        .default(Network.AlphanetV1)
+    )
+    .action(async (...args: Parameters<typeof batchCombineSudt>) => {
+      await batchCombineSudt(...args);
+    })
+  ;
+}
+
+export async function batchCombineSudt(payload: {
+  network: Network,
+  privateKey: HexString,
+  sudtLockArgs: HexString,
+  derivedCount: string,
+}) {
+  const derivedCount = mustBeInteger(payload.derivedCount, 'derivedCount');
+  const accounts = privateKeyToDerivedAccounts(addHexPrefix(payload.privateKey), derivedCount);
+  const promises = Promise.allSettled(accounts.map((account) => {
+    return combineSudtCells({
+      network: payload.network,
+      privateKey: account.privateKey,
+      sudtLockArgs: addHexPrefix(payload.sudtLockArgs),
+    });
+  }));
+
+  const results = await promises;
+  console.log(results);
+  return results;
+}
+
+async function combineSudtCells(payload: {
+  network: Network,
+  privateKey: HexString,
+  sudtLockArgs: HexString,
+  minCombineLimit?: number,
+}) {
+  const config = getConfig(payload.network);
+  const client = await createLightGodwokenByNetworkConfig(payload.privateKey, config);
+  const layer1Lock = client.provider.getLayer1Lock();
+  const lightGodwokenConfig = client.getConfig();
+
+  const collector = client.provider.ckbIndexer.collector({
+    lock: layer1Lock,
+    type: {
+      code_hash: lightGodwokenConfig.layer1Config.SCRIPTS.sudt.code_hash,
+      hash_type: lightGodwokenConfig.layer1Config.SCRIPTS.sudt.hash_type,
+      args: payload.sudtLockArgs,
+    },
+    // if sudt cell's data has more info than just amount (16 bytes), skip it
+    // because we don't know what the extension bytes contain
+    outputDataLenRange: ["0x10", "0x11"],
+  });
+
+  const cells: Cell[] = [];
+  let collectedCapacity = BI.from(0);
+  let collectedSudtAmount = BI.from(0);
+  for await (const cell of collector.collect()) {
+    collectedCapacity = collectedCapacity.add(cell.cell_output.capacity);
+    collectedSudtAmount = collectedSudtAmount.add(number.Uint128LE.unpack(cell.data));
+    cells.push(cell);
+  }
+
+  const minCombineLimit = payload.minCombineLimit ?? 5;
+  if (cells.length < minCombineLimit) {
+    const address = client.provider.getL1Address();
+    console.log(`[${address}] sudt cells less than min-combine-limit(${minCombineLimit}), skipping`);
+    return;
+  }
+
+  const outputSudtCell = generateOutputSudtCell(cells[0], collectedSudtAmount);
+  const returnCapacity = collectedCapacity.sub(outputSudtCell.cell_output.capacity);
+  const outputPureCell = {
+    cell_output: {
+      capacity: returnCapacity.toHexString(),
+      lock: layer1Lock,
+    },
+    data: '0x',
+  };
+
+  let txSkeleton = helpers.TransactionSkeleton({
+    cellProvider: client.provider.ckbIndexer,
+  });
+  txSkeleton = txSkeleton
+    .update('cellDeps', (cellDeps) => {
+      return cellDeps.push(...generateCellDeps(lightGodwokenConfig));
+    })
+    .update('inputs', (inputs) => {
+      return inputs.push(...cells);
+    })
+    .update('outputs', (outputs) => {
+      return outputs.push(outputSudtCell, outputPureCell);
+    })
+  ;
+
+  const unsignedTx = await client.payTxFee(txSkeleton);
+  const signedTx = await client.provider.signL1TxSkeleton(unsignedTx);
+  const txHash = await client.provider.sendL1Transaction(signedTx);
+  return {
+    txHash: txHash,
+    cells: cells.length,
+    collectedSudtAmount: collectedSudtAmount.toString(),
+    collectedCapacity: collectedCapacity.toString(),
+    returnCapacity: returnCapacity.toString(),
+  };
+}
+
+function generateOutputSudtCell(template: Cell, totalSudtAmount: BI) {
+  const outputSudtCell: Cell = {
+    cell_output: {
+      ...template.cell_output,
+    },
+    data: bytes.hexify(
+      number.Uint128LE.pack(totalSudtAmount)
+    ),
+  };
+
+  const requireCapacity = helpers.minimalCellCapacityCompatible(outputSudtCell);
+  outputSudtCell.cell_output.capacity = requireCapacity.toHexString();
+  return outputSudtCell;
+}
+
+function generateCellDeps(config: LightGodwokenConfig): CellDep[] {
+  const scripts = config.layer1Config.SCRIPTS;
+  return [
+    {
+      out_point: {
+        tx_hash: scripts.omni_lock.tx_hash,
+        index: scripts.omni_lock.index,
+      },
+      dep_type: scripts.omni_lock.dep_type,
+    },
+    {
+      out_point: {
+        tx_hash: scripts.secp256k1_blake160.tx_hash,
+        index: scripts.secp256k1_blake160.index,
+      },
+      dep_type: scripts.secp256k1_blake160.dep_type,
+    },
+    {
+      out_point: {
+        tx_hash: scripts.sudt.tx_hash,
+        index: scripts.sudt.index,
+      },
+      dep_type: scripts.sudt.dep_type,
+    },
+  ];
+}

--- a/scripts/light-godwoken-cli/src/commands/l1-transfer.ts
+++ b/scripts/light-godwoken-cli/src/commands/l1-transfer.ts
@@ -1,0 +1,105 @@
+import { utils } from 'ethers';
+import { Command, Option } from 'commander';
+import { helpers } from '@ckb-lumos/lumos';
+import { utils as lumosUtils, HexString } from '@ckb-lumos/base';
+import { createSudtTypeScript } from '../utils/ckb/sudt';
+import { createLightGodwoken } from '../utils/client';
+import { isAllDefinedOrAllNot } from '../utils/format';
+import { getConfig } from '../utils/config';
+import { Network } from '../config';
+
+export default function setupL1Transfer(program: Command) {
+  program
+    .command('l1-transfer')
+    .description('Transfer CKB to other address on layer1')
+    .requiredOption('-p, --private-key <HEX_STRING>', 'account private key')
+    .requiredOption('-c, --capacity <STRING>', 'transfer capacity (1:1CKB)')
+    .requiredOption('-r, --recipient <STRING>', 'The recipient layer1 address')
+    .option('-sl, --sudt-lock-args <HEX_STRING>', 'transfer sudt L1 lock_args')
+    .option('-sa, --sudt-amount <STRING>', 'transfer sudt amount')
+    .option('-sd, --sudt-decimals <STRING>', 'sudt decimals')
+    .addOption(
+      new Option('-n, --network <NETWORK>', 'network to use')
+        .choices(Object.values(Network))
+        .default(Network.TestnetV1)
+    )
+    .action(async (...args: Parameters<typeof l1Transfer>) => {
+      await l1Transfer(...args);
+    })
+  ;
+}
+
+export async function l1Transfer(params: {
+  privateKey: HexString;
+  network: Network;
+  capacity: string;
+  recipient: HexString;
+  sudtLockArgs?: string;
+  sudtAmount?: string;
+  sudtDecimals?: string;
+  waitForCompletion?: boolean;
+}) {
+  if (!isAllDefinedOrAllNot([params.sudtLockArgs, params.sudtAmount, params.sudtDecimals])) {
+    throw new Error('Missing param sudtLockArgs, or sudtAmount, or sudtDecimals');
+  }
+
+  const network = getConfig(params.network);
+  const client = await createLightGodwoken({
+    privateKey: params.privateKey,
+    rpc: network.rpc,
+    network: network.network,
+    version: network.version,
+    config: network.lightGodwokenConfig,
+  });
+
+  const lightGodwokenConfig = client.provider.getConfig();
+  try {
+    helpers.parseAddress(params.recipient, {
+      config: lightGodwokenConfig.lumosConfig as any,
+    });
+  } catch {
+    throw new Error('The recipient layer1 address is invalid');
+  }
+
+  const capacity = utils.parseUnits(params.capacity, 8);
+  const sudtType = params.sudtLockArgs
+    ? createSudtTypeScript(params.sudtLockArgs, lightGodwokenConfig)
+    : void 0;
+  const sudtAmount = params.sudtAmount
+    ? utils.parseUnits(params.sudtAmount, params.sudtDecimals).toHexString()
+    : '0x0';
+
+  console.debug(`[l1-transfer] from: ${client.provider.getL1Address()}`);
+  console.debug(`[l1-transfer] to: ${client.provider.getL2Address()}`);
+
+  if (sudtType) {
+    const typeHash = lumosUtils.computeScriptHash(sudtType);
+    console.debug(`[l1-transfer] sudt-type-hash: ${typeHash}`);
+    console.debug(`[l1-transfer] sudt-amount: ${params.sudtAmount}`);
+  } else {
+    console.debug(`[l1-transfer] capacity: ${params.capacity} CKB`);
+  }
+
+  const waitForCompletion = params.waitForCompletion !== false;
+  // @ts-ignore
+  const hash = await client.l1Transfer({
+    toAddress: params.recipient,
+    sudtType: sudtType,
+    amount: sudtType ? sudtAmount : capacity.toHexString(),
+  });
+
+  console.debug(`[l1-transfer] committed, tx-hash: ${hash}`);
+  if (waitForCompletion) {
+    try {
+      // @ts-ignore
+      await client.provider.waitForL1Transaction(hash);
+      console.debug(`[l1-transfer] succeed, tx-hash: ${hash}`);
+      return hash;
+    } catch (e) {
+      console.debug(`[l1-transfer] failed, tx-hash: ${hash}, error: ${e}`);
+      throw e;
+    }
+  } else {
+    return hash;
+  }
+}

--- a/scripts/light-godwoken-cli/src/index.ts
+++ b/scripts/light-godwoken-cli/src/index.ts
@@ -5,6 +5,7 @@ import settings from '../package.json';
 // for general usages
 import deposit from './commands/deposit';
 import withdraw from './commands/withdraw';
+import l1Transfer from './commands/l1-transfer';
 import getBalance from './commands/get-balance';
 import getTokenBalance from './commands/get-token-balance';
 import findTypeScript from './commands/find-script-tx';
@@ -12,13 +13,15 @@ import deploySudtErc20Proxy from './commands/deploy-sudt-erc20-proxy';
 // generating statistics
 import { setupGetLegacyWithdrawalsStats } from './commands/get-legacy-withdrawals-stats';
 // for testing only
-import testCatch from './commands/batch-prepare-sudt';
-import batchPrepareSudt from './commands/test-catch';
+import testCatch from './commands/test-catch';
+import batchPrepareSudt from './commands/batch-prepare-sudt';
+import batchCombineSudt from './commands/batch-combine-sudt';
 import batchDepositWithdraw from './commands/batch-deposit-withdraw';
 
 const commands = [
   deposit,
   withdraw,
+  l1Transfer,
   getBalance,
   getTokenBalance,
   findTypeScript,
@@ -28,6 +31,7 @@ const commands = [
 
   testCatch,
   batchPrepareSudt,
+  batchCombineSudt,
   batchDepositWithdraw,
 ];
 


### PR DESCRIPTION
### Description
Recently we found an issue in the `Batch Deposit & Withdraw On Alphanet_v1` CI . Our monitor showed that many blocks on Alphanet_v1 have `zero deposits`, because many accounts for the test don't have enough L1 capacity to complete their deposits. 

You can download the artifact file in this specific run for more detailed reports: 
https://github.com/godwokenrises/godwoken-tests/actions/runs/4190635487

And the reason why so many accounts lack of L1 capacity is because the workflow only makes sudt transactions therefore many ckb were splitted into new generated sudt cells, and the deposit method of the light-godwoken sdk prefers to collect pure ckb cells. 

For this reason, I added the `batch-combine-sudt` command to help clean the sudt cells created from the `Batch Deposit & Withdraw On Alphanet_v1` CI. The command simply collects the test sudt cells, and combine them all into one test sudt cell, and returns a pure ckb cell. The command is for mannual run only, and as I've tested it, the result was good. 

Please check this transaction as an example:
https://pudge.explorer.nervos.org/transaction/0x39c3975ee618ffe010e2cccbe9b4b6497071e1b507943f3d96a94fafeca9756d

Finally, I have re-enabled the `Batch Deposit & Withdraw On Alphanet_v1` CI to see if it is working again. 
If you see anything wrong with the command or the batch workflow, please point it out. 

### Changes
- Add `batch-combine-sudt` command in lgc
- Add `l1-transfer` command in lgc