### PR TITLE
chore: only run `Contract Tests workflow` at a time

### DIFF
--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -11,6 +11,13 @@ on:
   - cron:  '50 0 * * *' # every 24 hour
   workflow_dispatch:
 
+# Use concurrency to ensure that only a single job or workflow
+# using the same concurrency group will run at a time.
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions?query=workflow_dispatch#concurrency
+concurrency:
+  group: staging_environments
+  cancel-in-progress: false
+
 jobs:
   contract-tests:
     if: github.repository == 'godwokenrises/godwoken-tests'


### PR DESCRIPTION
Use concurrency to ensure that only a single job or workflow using the same concurrency group will run at a time.

see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions?query=workflow_dispatch#concurrency