### PR TITLE
chore: downgrade node version to 16

### DIFF
--- a/.github/workflows/axon-devnet.yml
+++ b/.github/workflows/axon-devnet.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
It appears that there is a cache bug in node version 18. I checkout out [the version of node that hardhat team is using](https://github.com/NomicFoundation/hardhat/blob/main/.github/workflows/hardhat-core-ci.yml#L34). It's node@14.  While I am currently using node@16 locally without any issues, it seems likely that this problem is related to the specific version of node being used.

