### PR TITLE
test: send non eip155 tx to Axon

### DIFF
--- a/contracts/test/nonEip155.js
+++ b/contracts/test/nonEip155.js
@@ -8,6 +8,12 @@ const { getTxReceipt } = require("../utils/receipt");
 
 const { ethers } = hardhat;
 
+// non-EIP-155 transactions are mainly to support EIP-1820. Many projects use
+// this method to support multi-chain contracts using the same address.
+//
+// EIP-155: The currently existing signature scheme using v = 27 and v = 28
+// remains valid and continues to operate under the same rules as it did
+// previously.
 describe("Non eip155 tx", function () {
   it("Send non eip155 tx", async function () {
     const [owner] = await ethers.getSigners();

--- a/contracts/test/nonEip155.js
+++ b/contracts/test/nonEip155.js
@@ -9,11 +9,6 @@ const { getTxReceipt } = require("../utils/receipt");
 const { ethers } = hardhat;
 
 describe("Non eip155 tx", function () {
-  //FIXME
-  if (isAxon()) {
-    return;
-  }
-
   it("Send non eip155 tx", async function () {
     const [owner] = await ethers.getSigners();
 


### PR DESCRIPTION
non-EIP-155 transactions are mainly to support [EIP-1820](https://eips.ethereum.org/EIPS/eip-1820). Many projects use this method to support multi-chain contracts using the same address.

> [EIP-155](https://eips.ethereum.org/EIPS/eip-155): The currently existing signature scheme using v = 27 and v = 28 remains valid and continues to operate under the same rules as it did previously.

