### PR TITLE
chore: remove the godwoken mainnet readonly test in workflows

### DIFF
--- a/.github/workflows/regression-contract-test.yml
+++ b/.github/workflows/regression-contract-test.yml
@@ -51,11 +51,3 @@ jobs:
       env:
         PRIVATE_KEY: ${{ secrets.GW_MAINNET_V1_PK1 }}
         PRIVATE_KEY2: ${{ secrets.GW_MAINNET_V1_PK2 }}
-    - name: Run tests on mainnet-readonly.godwoken.cf
-      working-directory: contracts
-      run: |
-        sed -i "s|v1.mainnet.godwoken.io|mainnet-readonly.godwoken.cf|g" hardhat.config.js
-        npm run test:gw_mainnet_v1
-      env:
-        PRIVATE_KEY: ${{ secrets.GW_MAINNET_V1_PK1 }}
-        PRIVATE_KEY2: ${{ secrets.GW_MAINNET_V1_PK2 }}


### PR DESCRIPTION
-  godwoken mainnet_v1 readonly cluster is deprecated so emove the godwoken mainnet readonly test in regression 